### PR TITLE
Initial scaffold for @openparachute/octopus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.DS_Store
+*.log
+.env
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# octopus
+
+This repo IS the octopus team layer. Tentacles working in this repo are
+helping develop the harness that other repos use.
+
+## Layout
+
+```
+src/
+  cli.ts              CLI entry — dispatches to subcommands
+  cli/
+    help.ts           `octopus help`
+    init.ts           `octopus init` — bootstraps a target repo
+    launch.ts         `octopus launch` — start tmux + Claude Code as team-lead
+    ui.ts             `octopus ui` — start the web dashboard
+    send.ts           `octopus send` — tmux send-keys to the team-lead
+    spawn.ts          `octopus spawn` — type /spawn into the team-lead
+    flags.ts          tiny long-flag parser
+    tmux.ts           thin tmux helpers for CLI subcommands
+  config.ts           re-exports for team config loading
+  paths.ts            path resolution: team config, public/, templates/
+  ui/                 the web dashboard (Hono + SSE on Bun)
+    server.tsx        Hono app + SSE streams + POST send/spawn/shutdown
+    state.ts          load config, build snapshot, derive status
+    tmux.ts           tmux capture-pane / send-keys / list-panes
+    render.tsx        JSX components: DashboardPage, PanePage
+    colors.ts         tentacle color palette
+    format.ts         relative-time formatting
+templates/            files written into target repos by `octopus init`
+public/               static assets served by the UI (CSS + JS)
+tests/                bun test suite
+```
+
+## Conventions
+
+- **Bun-native.** No bundler, no build step. The bin runs `.ts` directly via
+  `#!/usr/bin/env bun`. Tests are `bun test`.
+- **Loopback by default.** The web UI binds `127.0.0.1` unless `--host` /
+  `OCTOPUS_UI_HOST` says otherwise. The dashboard shells `tmux send-keys`
+  into every pane on the box — network-layer gating is the auth.
+- **Templates are the contract.** Files under `templates/` are written
+  verbatim into target repos by `octopus init`. When the slash command or
+  agent definitions evolve, update the template file directly — don't
+  re-author from scratch.
+- **No Parachute Vault dependency.** Octopus is the team layer — it must
+  work standalone. Vault, Daily, Agents, etc. are optional composers.
+- **Feature branches always.** Open a PR; never commit to main.
+
+## Tests
+
+```
+bun test
+```
+
+The suite exercises every route wire (smoke), the snapshot derivation logic
+(state), the path-resolution priority chain (paths), and the `init` template
+writer (init).
+
+## Running locally during development
+
+```
+bun src/cli.ts ui          # dashboard at http://127.0.0.1:6061
+bun src/cli.ts init        # bootstrap a target repo
+bun src/cli.ts launch      # tmux + Claude Code as team-lead
+```
+
+For UI development with hot-reload:
+
+```
+bun --hot src/cli.ts ui
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,173 @@
+# octopus
+
+A team layer for [Claude Code](https://docs.claude.com/claude-code) — spawn,
+observe, and coordinate **tentacles** (Claude Code teammates) in any repo.
+
+One central session — the **team-lead** — holds the conversation. From there,
+focused tentacles get spawned into their own tmux panes and pinned to a
+working directory. Each tentacle reads its `CLAUDE.md`, does the focused
+work, self-reviews, and reports back. The team-lead stays at the
+big-picture level; depth happens in parallel.
+
+A small, dark web dashboard shows every live pane at a glance and lets you
+type into any of them from a browser or tablet over Tailscale.
+
+> Octopus is one piece of the [Parachute](https://github.com/ParachuteComputer)
+> family. It is **standalone by design** — no Vault, no agents service, no
+> external dependencies beyond `tmux` + `claude` + `bun`.
+
+## Install
+
+```bash
+bun add -g @openparachute/octopus
+```
+
+You'll need [`bun`](https://bun.com), [`tmux`](https://github.com/tmux/tmux),
+and the [Claude Code CLI](https://docs.claude.com/claude-code) on PATH.
+
+## Quick start
+
+From the root of any repo:
+
+```bash
+octopus init        # writes .claude/commands + agents + octopus.md
+octopus launch      # starts tmux + Claude Code as the team-lead
+octopus ui          # opens the web dashboard at http://127.0.0.1:6061
+```
+
+The team-lead is now ready. Type `/spawn <name> <cwd> <prompt>` in its pane
+to spin up a tentacle, or use the **🐙 spawn** button in the dashboard.
+
+## How it works
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  team-lead (primary Claude Code session, in tmux)       │
+│  – holds the conversation                               │
+│  – dispatches `/spawn` to create tentacles              │
+│  – receives `/report` summaries from tentacles          │
+└─────────────────┬───────────────────────────────────────┘
+                  │ Agent({ subagent_type: "tentacle", … })
+                  ▼
+┌──────────┐ ┌──────────┐ ┌──────────┐
+│ tentacle │ │ tentacle │ │ tentacle │   each in its own
+│ pane #1  │ │ pane #2  │ │ pane #N  │   tmux pane, pinned
+└──────────┘ └──────────┘ └──────────┘   to a working dir
+
+┌─────────────────────────────────────────────────────────┐
+│  octopus ui  →  http://127.0.0.1:6061                   │
+│  – live grid of every pane                              │
+│  – click any card to expand scrollback + send keys      │
+│  – spawn / shutdown tentacles from the browser          │
+└─────────────────────────────────────────────────────────┘
+```
+
+The team config (`config.json`) is the source of truth for the roster. The
+dashboard reads it, reconciles against live tmux panes by name, and pushes
+SSE updates every 2s.
+
+## CLI reference
+
+### `octopus init [--team <name>] [--cwd <path>]`
+
+Bootstrap the current repo. Writes:
+
+- `.claude/commands/spawn.md` — `/spawn` slash command
+- `.claude/commands/report.md` — `/report` slash command
+- `.claude/agents/tentacle.md` — tentacle agent definition
+- `.claude/agents/reviewer.md` — fresh-eyes code reviewer
+- `.claude/octopus.md` — short conventions snippet linked from `CLAUDE.md`
+
+Idempotent: re-running overwrites the four template files but preserves the
+rest of `CLAUDE.md`. Default team name is `octopus`.
+
+### `octopus launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>]`
+
+Start (or attach to) a tmux session running Claude Code as the team-lead.
+Defaults: team `octopus`, cwd `$PWD`, session name = team name. Inside an
+existing tmux session it does `switch-client` instead of `attach`.
+
+### `octopus ui [--team <name>] [--port 6061] [--host 127.0.0.1] [--team-config <path>]`
+
+Start the web dashboard. Loopback only by default. Opt into LAN/Tailscale
+exposure with `--host 0.0.0.0`. The team config path is resolved from:
+
+1. `--team-config` flag (or `OCTOPUS_TEAM_CONFIG` env)
+2. `<cwd>/.claude/teams/<team>/config.json` (project-local)
+3. `~/.claude/teams/<team>/config.json` (home-dir, Claude Code default)
+
+### `octopus send <text...> [--session <name>]`
+
+Send keystrokes to the team-lead's tmux session. Useful for slash commands
+or status pings from a script.
+
+```bash
+octopus send /compact
+octopus send "check the deploy status"
+```
+
+### `octopus spawn <name> <cwd> <prompt...> [--session <name>]`
+
+Convenience for typing `/spawn <name> <cwd> <prompt>` into the team-lead's
+pane from a terminal. The `octopus ui` spawn modal does the same thing.
+
+## Web dashboard
+
+The dashboard lays the team out as an octopus: the **team-lead is the head**
+at the top, **tentacles are the arms** in the grid below. Each card shows
+status (`idle` / `working` / `dead`), the live pane id, recent output, and
+an **open** link that expands the scrollback with a send-keys input and
+useful key controls (`Esc`, `Tab`, `Shift+Tab`, arrows, `/compact`, etc.).
+
+Real-time via Server-Sent Events polling tmux every 2s. SSR-first — `curl /`
+gives a readable dashboard with no JS.
+
+### API surface
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET`  | `/api/state`            | Full snapshot |
+| `GET`  | `/api/stream`           | SSE — snapshot every 2s |
+| `GET`  | `/api/pane/:name`       | One-shot scrollback |
+| `GET`  | `/api/stream/pane/:name`| SSE — pane scrollback every 2s |
+| `POST` | `/api/panes/:name/send` | tmux send-keys (text or key mode) |
+| `POST` | `/api/spawn`            | Type `/spawn …` into the team-lead |
+| `POST` | `/api/shutdown/:name`   | Send `/exit` to a tentacle |
+| `GET`  | `/api/spawn-targets`    | Datalist suggestions for the spawn modal |
+
+## Auth
+
+**None at the app layer.** This server shells `tmux send-keys` into every
+pane on the box — it is *intentionally* gated at the network layer, not the
+app layer. Bind it to localhost or a Tailscale-only interface and rely on
+network ACLs. Do not expose it on the open internet.
+
+## Where octopus sits in the Parachute family
+
+Octopus is one piece of [Parachute](https://github.com/ParachuteComputer):
+small things, loosely joined.
+
+- **[parachute-vault](https://github.com/ParachuteComputer/parachute-vault)** —
+  durable knowledge graph. Optional. If present, your tentacles can persist
+  reports as `uni/handoff` notes.
+- **[parachute-agents](https://github.com/ParachuteComputer/parachute-agents)** —
+  hosted agent runtime. Optional. Octopus tentacles run *in your terminal* via
+  Claude Code; agents service runs them remotely.
+- **[@openparachute/cli](https://github.com/ParachuteComputer/openparachute-cli)** —
+  umbrella `parachute` command that dispatches to any `parachute-*` binary on
+  PATH. Octopus ships `parachute-octopus` for that pattern; both `octopus`
+  and `parachute octopus …` work.
+
+Each piece stands alone. Compose what you want, leave the rest.
+
+## Contributing
+
+- Conventions live in
+  [parachute-patterns](https://github.com/ParachuteComputer/parachute-patterns).
+  Cross-module changes (naming, brand, schemas) start there.
+- Feature branches → PR → review → merge. No direct commits to `main`.
+- Bun-native: no bundler, no build step. Tests are `bun test`.
+
+## License
+
+AGPL-3.0-or-later. Same as the rest of the Parachute family.

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@openparachute/octopus",
+      "dependencies": {
+        "hono": "^4.6.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.5.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@openparachute/octopus",
+  "version": "0.1.0",
+  "description": "Team layer for Claude Code — spawn, observe, and coordinate tentacles (Claude Code teammates) in any repo.",
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "bin": {
+    "parachute-octopus": "./src/cli.ts",
+    "octopus": "./src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun src/cli.ts",
+    "ui": "bun src/cli.ts ui",
+    "dev": "bun --hot src/cli.ts ui",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "files": [
+    "src",
+    "templates",
+    "public",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "claude-code",
+    "agents",
+    "octopus",
+    "team",
+    "tmux",
+    "parachute"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ParachuteComputer/octopus.git"
+  },
+  "homepage": "https://github.com/ParachuteComputer/octopus",
+  "bugs": {
+    "url": "https://github.com/ParachuteComputer/octopus/issues"
+  },
+  "engines": {
+    "bun": ">=1.1.0"
+  },
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.5.0"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,548 @@
+// Octopus dashboard client. Keeps the SSR shell intact and patches card
+// internals on each state push. Minimal deps — vanilla DOM.
+
+const grid = document.getElementById("grid");
+const heroSection = document.querySelector(".hero-section");
+const heroCard = document.getElementById("hero-card");
+const search = document.getElementById("search");
+const refreshBtn = document.getElementById("refresh-btn");
+const refreshIndicator = document.getElementById("refresh-indicator");
+
+// Keep in sync with src/colors.ts — Parachute-tuned tints against forest-dark bg.
+const colorMap = {
+  blue: "#8AA6BF",
+  yellow: "#D4BC7E",
+  purple: "#B09AC7",
+  orange: "#D4A373",
+  cyan: "#8CCFCE",
+  green: "#7AB09D",
+  pink: "#C9A0AA",
+  red: "#C88A7D",
+  teal: "#6FA5A0",
+  slate: "#9B9590",
+};
+
+function colorFor(name) {
+  return colorMap[name] ?? colorMap.slate;
+}
+
+function formatAge(ms) {
+  if (ms == null) return "—";
+  const s = Math.round(ms / 1000);
+  if (s < 2) return "just now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+function formatJoinedAt(ms) {
+  const d = new Date(ms);
+  const now = new Date();
+  const sameDay = d.toDateString() === now.toDateString();
+  const time = d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  if (sameDay) return `today · ${time}`;
+  const date = d.toLocaleDateString([], { month: "short", day: "numeric" });
+  return `${date} · ${time}`;
+}
+
+function escapeHtml(s) {
+  return (s ?? "").replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]),
+  );
+}
+
+function tailHtml(t) {
+  if (t.lastTail && t.lastTail.length) {
+    return `<pre class="tail" aria-label="recent output from ${escapeHtml(t.name)}">${escapeHtml(t.lastTail.join("\n"))}</pre>`;
+  }
+  const msg = t.status === "dead" ? "pane not found in live tmux" : "quiet for a moment";
+  return `<pre class="tail tail-quiet" aria-label="recent output from ${escapeHtml(t.name)}"><span class="quiet-line">${msg}</span></pre>`;
+}
+
+function renderCard(t) {
+  const accent = colorFor(t.color);
+  const classes = ["card", `card-${t.status}`];
+  if (t.stale) classes.push("card-stale");
+
+  return `
+<article class="${classes.join(" ")}" data-name="${escapeHtml(t.name)}" data-cwd="${escapeHtml(t.cwdShort)}" data-status="${t.status}" style="--tentacle: ${accent};">
+  <header class="card-head">
+    <div class="card-title">
+      <span class="status-dot status-${t.status}" aria-label="${t.status}"></span>
+      <h2 class="tentacle-name" style="color: ${accent};">${escapeHtml(t.name)}</h2>
+    </div>
+    <div class="card-meta">
+      <span class="pill pill-${t.agentType}">${escapeHtml(t.agentType)}</span>
+      ${t.stale ? `<span class="pill pill-warn" title="config tmuxPaneId doesn't match any live pane">stale</span>` : ""}
+      <button type="button" class="card-close" data-shutdown="${escapeHtml(t.name)}" title="Shut down ${escapeHtml(t.name)}" aria-label="Shut down ${escapeHtml(t.name)}">×</button>
+    </div>
+  </header>
+  <dl class="card-facts">
+    <div><dt>cwd</dt><dd class="mono" title="${escapeHtml(t.cwd)}">${escapeHtml(t.cwdShort || "—")}</dd></div>
+    <div><dt>pane</dt><dd class="mono">${t.livePaneId ? escapeHtml(t.livePaneId) : `<span class="dim">dead</span>`}</dd></div>
+    <div><dt>activity</dt><dd class="age" data-age="${t.lastActivityMs ?? ""}">${formatAge(t.lastActivityMs)}</dd></div>
+    <div><dt>joined</dt><dd>${formatJoinedAt(t.joinedAt)}</dd></div>
+  </dl>
+  ${tailHtml(t)}
+  <footer class="card-foot"><a class="btn btn-primary" href="/pane/${encodeURIComponent(t.name)}">open</a></footer>
+</article>`;
+}
+
+function renderHero(t) {
+  const accent = colorFor(t.color) || "#7AB09D";
+  const tailContent = t.lastTail && t.lastTail.length
+    ? escapeHtml(t.lastTail.slice(-20).join("\n"))
+    : `<span class="quiet-line">quiet for a moment</span>`;
+  return `
+<div class="hero-head">
+  <div class="hero-glyph" aria-hidden="true">${OCTOPUS_SVG}</div>
+  <div class="hero-titles">
+    <div class="hero-row">
+      <span class="status-dot status-${t.status}" aria-label="${t.status}"></span>
+      <h2 class="hero-name">${escapeHtml(t.name)}</h2>
+      <span class="pill pill-team-lead">team-lead</span>
+    </div>
+    <div class="hero-sub">
+      <span class="mono dim" title="${escapeHtml(t.cwd)}">${escapeHtml(t.cwdShort || "—")}</span>
+      <span class="hero-dot">·</span>
+      <span class="mono dim">pane ${t.livePaneId ? escapeHtml(t.livePaneId) : "—"}</span>
+      <span class="hero-dot">·</span>
+      <span class="age" data-age="${t.lastActivityMs ?? ""}">${formatAge(t.lastActivityMs)}</span>
+    </div>
+  </div>
+  <a class="btn btn-primary hero-open" href="/pane/${encodeURIComponent(t.name)}">open</a>
+</div>
+<pre class="hero-tail" aria-label="recent output from ${escapeHtml(t.name)}">${tailContent}</pre>`;
+}
+
+// Keep in sync with src/render.tsx OctopusGlyph.
+const OCTOPUS_SVG = `<svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<path d="M20 26 C20 16, 26 10, 32 10 S44 16, 44 26 V30 C44 32, 42 34, 40 34 H24 C22 34, 20 32, 20 30 Z" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/>
+<circle cx="27.5" cy="23" r="1.4" fill="currentColor"/>
+<circle cx="36.5" cy="23" r="1.4" fill="currentColor"/>
+<path d="M23 34 C21 42, 15 46, 18 56" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+<path d="M30 34 C31 42, 26 50, 30 58" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+<path d="M34 34 C33 42, 38 50, 34 58" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+<path d="M41 34 C43 42, 49 46, 46 56" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+</svg>`;
+
+function applyHero(teamLead) {
+  if (!heroCard) return;
+  const accent = colorFor(teamLead.color) || "#7AB09D";
+  heroCard.style.setProperty("--tentacle", accent);
+  heroCard.dataset.status = teamLead.status;
+  heroCard.className = `hero hero-${teamLead.status}`;
+  heroCard.innerHTML = renderHero(teamLead);
+  // Arms-flowing glow when team-lead is working.
+  if (heroSection) {
+    heroSection.classList.toggle("is-flowing", teamLead.status === "working");
+  }
+}
+
+// Track which mentions we've already pulsed so we don't re-trigger every poll.
+const lastMentionSet = new Set();
+
+function applyMentions(mentioned) {
+  if (!mentioned || !mentioned.length) {
+    lastMentionSet.clear();
+    return;
+  }
+  const fresh = mentioned.filter((n) => !lastMentionSet.has(n));
+  // Keep set bounded but always reflect the current snapshot.
+  lastMentionSet.clear();
+  mentioned.forEach((n) => lastMentionSet.add(n));
+  for (const name of fresh) {
+    const card = grid?.querySelector(`.card[data-name="${cssEscape(name)}"]`);
+    if (!card) continue;
+    card.classList.remove("is-mentioned");
+    void card.offsetWidth;
+    card.classList.add("is-mentioned");
+    setTimeout(() => card.classList.remove("is-mentioned"), 3000);
+  }
+}
+
+function cssEscape(s) {
+  return (window.CSS && CSS.escape) ? CSS.escape(s) : s.replace(/"/g, '\\"');
+}
+
+function applyState(snap) {
+  const teamLead = snap.tentacles.find((t) => t.agentType === "team-lead");
+  const others = snap.tentacles.filter((t) => t.agentType !== "team-lead");
+
+  // Header pill counts
+  const alive = snap.tentacles.filter((t) => t.status !== "dead").length;
+  document.querySelectorAll("[data-stat]").forEach((el) => {
+    const key = el.dataset.stat;
+    const val = el.querySelector(".stat-value");
+    if (!val) return;
+    if (key === "alive") val.textContent = String(alive);
+    else if (key === "roster") val.textContent = String(snap.totalMembers);
+    else if (key === "panes") val.textContent = String(snap.livePanes);
+  });
+
+  if (teamLead) applyHero(teamLead);
+
+  if (!grid) return;
+
+  // Diff cards by name — only replace ones whose signature changed.
+  const next = new Map(others.map((t) => [t.name, t]));
+  const existing = new Map();
+  grid.querySelectorAll(".card").forEach((el) => existing.set(el.dataset.name, el));
+
+  // Remove cards no longer in snapshot
+  for (const [name, el] of existing) {
+    if (!next.has(name)) el.remove();
+  }
+
+  const fragment = document.createDocumentFragment();
+  const template = document.createElement("div");
+  for (const [name, t] of next) {
+    const sig = signature(t);
+    const el = existing.get(name);
+    if (el && el.dataset.sig === sig) continue;
+    template.innerHTML = renderCard(t);
+    const fresh = template.firstElementChild;
+    fresh.dataset.sig = sig;
+    if (el) {
+      el.replaceWith(fresh);
+      fresh.classList.add("is-updated");
+      setTimeout(() => fresh.classList.remove("is-updated"), 1000);
+    } else {
+      fragment.appendChild(fresh);
+    }
+  }
+  if (fragment.childNodes.length) grid.appendChild(fragment);
+
+  applySearch();
+  if (teamLead && Array.isArray(teamLead.recentlyMentioned)) {
+    applyMentions(teamLead.recentlyMentioned);
+  }
+}
+
+function signature(t) {
+  return [
+    t.status,
+    t.stale,
+    t.livePaneId,
+    t.lastActivityMs,
+    (t.lastTail || []).join("\n"),
+  ].join("::");
+}
+
+// Connect SSE stream -------------------------------------------------
+
+let es;
+let retry = 0;
+
+function connect() {
+  es = new EventSource("/api/stream");
+  es.addEventListener("state", (ev) => {
+    retry = 0;
+    if (refreshIndicator) {
+      refreshIndicator.textContent = "live";
+      refreshIndicator.classList.remove("disconnected");
+    }
+    try {
+      applyState(JSON.parse(ev.data));
+    } catch (e) {
+      console.error("bad state payload", e);
+    }
+  });
+  es.addEventListener("error", () => {
+    if (refreshIndicator) {
+      refreshIndicator.textContent = "offline";
+      refreshIndicator.classList.add("disconnected");
+    }
+    es.close();
+    retry = Math.min(retry + 1, 5);
+    setTimeout(connect, 500 * retry);
+  });
+}
+
+connect();
+
+// Manual refresh ---------------------------------------------------
+
+async function manualRefresh() {
+  try {
+    const r = await fetch("/api/state", { cache: "no-store" });
+    if (!r.ok) throw new Error(String(r.status));
+    applyState(await r.json());
+  } catch (err) {
+    toast(`refresh failed: ${err.message}`, true);
+  }
+}
+
+refreshBtn?.addEventListener("click", () => {
+  if (refreshBtn) {
+    refreshBtn.classList.remove("spinning");
+    void refreshBtn.offsetWidth;
+    refreshBtn.classList.add("spinning");
+    setTimeout(() => refreshBtn.classList.remove("spinning"), 450);
+  }
+  manualRefresh();
+});
+
+// Search ----------------------------------------------------------
+
+function applySearch() {
+  const q = (search?.value ?? "").trim().toLowerCase();
+  grid?.querySelectorAll(".card").forEach((el) => {
+    if (!q) {
+      el.classList.remove("is-hidden");
+      return;
+    }
+    const name = (el.dataset.name || "").toLowerCase();
+    const cwd = (el.dataset.cwd || "").toLowerCase();
+    if (name.includes(q) || cwd.includes(q)) el.classList.remove("is-hidden");
+    else el.classList.add("is-hidden");
+  });
+}
+
+search?.addEventListener("input", applySearch);
+
+// Keyboard shortcuts ---------------------------------------------
+
+document.addEventListener("keydown", (e) => {
+  const tag = document.activeElement?.tagName;
+  const typing = tag === "INPUT" || tag === "TEXTAREA";
+  if (e.key === "/" && !typing) {
+    e.preventDefault();
+    search?.focus();
+    search?.select();
+  } else if (e.key === "r" && !typing && !e.metaKey && !e.ctrlKey) {
+    e.preventDefault();
+    manualRefresh();
+  } else if (e.key === "n" && !typing && !e.metaKey && !e.ctrlKey) {
+    e.preventDefault();
+    openSpawnModal();
+  } else if (e.key === "Escape") {
+    const open = document.querySelector(".modal-backdrop:not([hidden])");
+    if (open) {
+      closeModal(open.id);
+      return;
+    }
+    if (typing && search && document.activeElement === search) {
+      search.blur();
+      search.value = "";
+      applySearch();
+    }
+  }
+});
+
+// Modals ---------------------------------------------------------
+// Modals are SSR-only — applyState never re-renders them, so it's safe to
+// cache references to their inputs/buttons at script load.
+
+const focusReturnStack = [];
+
+function focusableIn(el) {
+  return el.querySelectorAll(
+    "a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+  );
+}
+
+function openModal(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  focusReturnStack.push(document.activeElement);
+  el.hidden = false;
+  requestAnimationFrame(() => el.classList.add("is-open"));
+  const focusTarget = el.querySelector("input, textarea, button");
+  focusTarget?.focus();
+}
+
+function closeModal(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.remove("is-open");
+  setTimeout(() => {
+    el.hidden = true;
+  }, 180);
+  // Clear any modal-scoped state.
+  if (id === "shutdown-modal") pendingShutdown = null;
+  if (id === "spawn-modal") {
+    const err = document.getElementById("spawn-error");
+    if (err) { err.textContent = ""; err.hidden = true; }
+  }
+  // Restore focus to whatever triggered the open.
+  const prev = focusReturnStack.pop();
+  prev?.focus?.();
+}
+
+document.querySelectorAll("[data-modal-close]").forEach((btn) => {
+  btn.addEventListener("click", () => closeModal(btn.dataset.modalClose));
+});
+
+// Click on backdrop (but not modal body) closes.
+document.querySelectorAll(".modal-backdrop").forEach((bd) => {
+  bd.addEventListener("click", (e) => {
+    if (e.target === bd) closeModal(bd.id);
+  });
+});
+
+// Trap Tab inside the open modal so keyboard users can't escape into the
+// page behind it while the modal is up.
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "Tab") return;
+  const open = document.querySelector(".modal-backdrop:not([hidden])");
+  if (!open) return;
+  const modal = open.querySelector(".modal");
+  if (!modal) return;
+  const items = Array.from(focusableIn(modal));
+  if (items.length === 0) return;
+  const first = items[0];
+  const last = items[items.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+});
+
+// Spawn ---------------------------------------------------------
+
+const spawnBtn = document.getElementById("spawn-btn");
+const spawnForm = document.getElementById("spawn-form");
+const targetList = document.getElementById("spawn-target-list");
+let targetsLoaded = false;
+
+async function loadSpawnTargets() {
+  if (targetsLoaded || !targetList) return;
+  try {
+    const r = await fetch("/api/spawn-targets");
+    const { targets } = await r.json();
+    targetList.innerHTML = (targets ?? [])
+      .map((t) => `<option value="${escapeHtml(t)}"></option>`)
+      .join("");
+    targetsLoaded = true;
+  } catch {
+    // non-fatal
+  }
+}
+
+function openSpawnModal() {
+  loadSpawnTargets();
+  openModal("spawn-modal");
+}
+
+spawnBtn?.addEventListener("click", openSpawnModal);
+
+const spawnError = document.getElementById("spawn-error");
+
+function showSpawnError(msg) {
+  if (!spawnError) return;
+  spawnError.textContent = msg;
+  spawnError.hidden = false;
+}
+function clearSpawnError() {
+  if (!spawnError) return;
+  spawnError.textContent = "";
+  spawnError.hidden = true;
+}
+
+spawnForm?.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  clearSpawnError();
+  const data = new FormData(spawnForm);
+  const body = {
+    name: String(data.get("name") ?? "").trim(),
+    cwd: String(data.get("cwd") ?? "").trim(),
+    prompt: String(data.get("prompt") ?? "").trim(),
+    cloneUrl: String(data.get("cloneUrl") ?? "").trim(),
+  };
+  const submit = spawnForm.querySelector("button[type=submit]");
+  const submitLabel = submit.textContent;
+  submit.disabled = true;
+  if (body.cloneUrl) submit.textContent = "cloning…";
+  try {
+    const res = await fetch("/api/spawn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const j = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      // Inline error keeps the user's input visible so they can correct it.
+      showSpawnError(j.error ?? `HTTP ${res.status}`);
+      return;
+    }
+    toast(`/spawn typed to team-lead · watch the hero card for ${body.name}`);
+    spawnForm.reset();
+    closeModal("spawn-modal");
+  } catch (err) {
+    showSpawnError(err.message);
+  } finally {
+    submit.disabled = false;
+    submit.textContent = submitLabel;
+  }
+});
+
+// Shutdown -----------------------------------------------------
+
+const shutdownModal = document.getElementById("shutdown-modal");
+const shutdownConfirm = document.getElementById("shutdown-confirm");
+const shutdownNameEl = document.getElementById("shutdown-name");
+let pendingShutdown = null;
+
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest("[data-shutdown]");
+  if (!btn) return;
+  e.preventDefault();
+  e.stopPropagation();
+  pendingShutdown = btn.dataset.shutdown;
+  if (shutdownNameEl) shutdownNameEl.textContent = pendingShutdown;
+  openModal("shutdown-modal");
+});
+
+shutdownConfirm?.addEventListener("click", async () => {
+  if (!pendingShutdown) return;
+  const name = pendingShutdown;
+  shutdownConfirm.disabled = true;
+  try {
+    const res = await fetch(`/api/shutdown/${encodeURIComponent(name)}`, { method: "POST" });
+    const j = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast(`shutdown failed: ${j.error ?? res.status}`, true);
+      return;
+    }
+    toast(`shutdown queued · ${name} (${j.method})`);
+    closeModal("shutdown-modal");
+  } catch (err) {
+    toast(`shutdown failed: ${err.message}`, true);
+  } finally {
+    shutdownConfirm.disabled = false;
+    pendingShutdown = null;
+  }
+});
+
+// Ticking ages — cheap visual refresh between SSE pushes
+setInterval(() => {
+  document.querySelectorAll(".age").forEach((el) => {
+    const raw = el.getAttribute("data-age");
+    if (!raw) return;
+    const ms = Number(raw) + 1000;
+    el.setAttribute("data-age", String(ms));
+    el.textContent = formatAge(ms);
+  });
+}, 1000);
+
+// Toast -----------------------------------------------------------
+
+function toast(msg, isError = false) {
+  const el = document.createElement("div");
+  el.className = "toast" + (isError ? " toast-error" : "");
+  el.textContent = msg;
+  document.body.appendChild(el);
+  requestAnimationFrame(() => el.classList.add("toast-show"));
+  setTimeout(() => {
+    el.classList.remove("toast-show");
+    setTimeout(() => el.remove(), 220);
+  }, 2400);
+}

--- a/public/pane.js
+++ b/public/pane.js
@@ -1,0 +1,116 @@
+// Expanded pane view — live scrollback + send input.
+
+const form = document.getElementById("send-form");
+const input = document.getElementById("send-input");
+const scrollback = document.getElementById("scrollback");
+const name = form?.dataset.name;
+if (!name) throw new Error("missing tentacle name");
+
+function atBottom(el) {
+  return el.scrollHeight - el.clientHeight - el.scrollTop < 40;
+}
+
+let es;
+let retry = 0;
+
+function connect() {
+  es = new EventSource(`/api/stream/pane/${encodeURIComponent(name)}`);
+  es.addEventListener("pane", (ev) => {
+    retry = 0;
+    try {
+      const { output } = JSON.parse(ev.data);
+      const stick = atBottom(scrollback);
+      scrollback.textContent = output || "(no output)";
+      if (stick) scrollback.scrollTop = scrollback.scrollHeight;
+    } catch (err) {
+      console.error(err);
+    }
+  });
+  es.addEventListener("gone", () => {
+    es.close();
+    scrollback.textContent += "\n\n— tentacle is gone —";
+  });
+  es.addEventListener("error", () => {
+    es.close();
+    retry = Math.min(retry + 1, 5);
+    setTimeout(connect, 500 * retry);
+  });
+}
+
+connect();
+scrollback.scrollTop = scrollback.scrollHeight;
+
+async function send(text, enter = true) {
+  if (!text) return;
+  return await postSend({ text, enter, mode: "text" }, `sent to ${name}`);
+}
+
+async function sendKey(key) {
+  if (!key) return;
+  return await postSend({ text: key, mode: "key" }, `${key} → ${name}`);
+}
+
+async function postSend(body, successToast) {
+  try {
+    const res = await fetch(`/api/panes/${encodeURIComponent(name)}/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast(`send failed: ${data.error ?? res.status}`, true);
+      return false;
+    }
+    toast(successToast);
+    return true;
+  } catch (err) {
+    toast(`send failed: ${err.message}`, true);
+    return false;
+  }
+}
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const text = input.value;
+  if (!text.trim()) return;
+  input.disabled = true;
+  const ok = await send(text, true);
+  input.disabled = false;
+  if (ok) input.value = "";
+  input.focus();
+});
+
+document.querySelectorAll("[data-send]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    send(btn.getAttribute("data-send"), true);
+  });
+});
+
+document.querySelectorAll("[data-send-key]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    sendKey(btn.getAttribute("data-send-key"));
+  });
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    if (document.activeElement === input) {
+      input.blur();
+    } else {
+      window.location.href = "/";
+    }
+  }
+});
+
+function toast(msg, isError = false) {
+  const el = document.createElement("div");
+  el.className = "toast" + (isError ? " toast-error" : "");
+  el.textContent = msg;
+  document.body.appendChild(el);
+  requestAnimationFrame(() => el.classList.add("toast-show"));
+  setTimeout(() => {
+    el.classList.remove("toast-show");
+    setTimeout(() => el.remove(), 220);
+  }, 2200);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,1478 @@
+/* Octopus UI — Parachute dark variant.
+   Typography: Inter (UI chrome), Fraunces (display accents), JetBrains Mono (pane output).
+   Palette sourced from parachute-daily/lib/core/theme/design_tokens.dart. */
+
+:root {
+  /* Parachute palette (dark variant) */
+  --bg: #0f1715;                    /* forest-tinted night */
+  --bg-raised: #192823;             /* card */
+  --bg-elev: #1e3029;               /* hover */
+  --bg-hover: #213630;
+  --bg-tail: #0a1311;               /* pane output bg */
+
+  --forest: #7AB09D;                /* nightForest — primary accent */
+  --forest-dim: rgba(122, 176, 157, 0.14);
+  --forest-mist: rgba(212, 229, 223, 0.08);
+  --turquoise: #8CCFCE;             /* nightTurquoise — secondary */
+  --turquoise-dim: rgba(140, 207, 206, 0.14);
+
+  --border: rgba(122, 176, 157, 0.15);
+  --border-strong: rgba(122, 176, 157, 0.28);
+
+  --text: #E8E5E1;                  /* nightText — warm */
+  --text-dim: #A09B95;              /* nightTextSecondary */
+  --text-muted: #7a7570;
+
+  --driftwood: #9B9590;             /* warm gray */
+  --amber: #D4A373;                 /* stale / warn */
+  --amber-dim: rgba(212, 163, 115, 0.3);
+
+  --accent: var(--forest);
+  --accent-dim: var(--forest-dim);
+
+  --ok: var(--forest);
+  --warn: var(--amber);
+  --err: #c88a7d;
+
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --ui: "Inter var", Inter, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --display: "Fraunces", "Inter var", Inter, Georgia, serif;
+
+  --radius: 12px;
+  --radius-sm: 7px;
+  --pad: 20px;
+  --shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset;
+  --shadow-lift: 0 6px 24px -8px rgba(0, 0, 0, 0.5), 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--ui);
+  font-feature-settings: "cv11", "ss01", "ss03";
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Silk drift: very slow, very faint light on the upper-right.
+   Never distracting — 90s cycle, <8% alpha. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: -25%;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 55% 45% at 80% 15%, rgba(140, 207, 206, 0.07), transparent 60%),
+    radial-gradient(ellipse 50% 40% at 15% 90%, rgba(122, 176, 157, 0.05), transparent 60%);
+  animation: silkDrift 80s ease-in-out infinite alternate;
+  will-change: transform;
+}
+
+@keyframes silkDrift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(-3%, 2%, 0) scale(1.08);
+  }
+}
+
+body > * {
+  position: relative;
+  z-index: 1;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.mono {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0;
+}
+
+.dim {
+  color: var(--text-dim);
+}
+
+.num {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Header =================================================== */
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(15, 23, 21, 0.82);
+  backdrop-filter: saturate(160%) blur(12px);
+  -webkit-backdrop-filter: saturate(160%) blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.app-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 28px;
+  max-width: 1600px;
+  margin: 0 auto;
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.brand-back:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.brand-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--forest);
+}
+
+.brand-glyph svg {
+  width: 100%;
+  height: 100%;
+}
+
+.brand-name {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.015em;
+  font-variation-settings: "SOFT" 50, "WONK" 0;
+}
+
+.brand-team {
+  color: var(--text-dim);
+  font-size: 13px;
+  font-family: var(--mono);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* Labeled chip pills — used at all widths now (was mobile-only). Reads as
+   information instead of a debugger strip of bare numbers. */
+.stat-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-raised);
+  line-height: 1.15;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.stat-pill:hover {
+  border-color: var(--border-strong);
+}
+
+.stat-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  color: var(--text-muted);
+}
+
+.refresh-stat {
+  border-color: rgba(140, 207, 206, 0.22);
+  background: var(--turquoise-dim);
+}
+
+.refresh-stat .stat-value {
+  color: var(--turquoise);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 13.5px;
+  letter-spacing: 0.01em;
+}
+
+.refresh-stat .stat-value::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--turquoise);
+  box-shadow: 0 0 0 0 rgba(140, 207, 206, 0.55);
+  animation: streamBreathe 2.6s ease-in-out infinite;
+}
+
+.refresh-stat .stat-value.disconnected {
+  color: var(--driftwood);
+  text-decoration: underline dashed;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--amber-dim);
+}
+
+.refresh-stat .stat-value.disconnected::before {
+  background: var(--driftwood);
+  animation: none;
+  box-shadow: none;
+  opacity: 0.6;
+}
+
+@keyframes streamBreathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(140, 207, 206, 0.4);
+    filter: blur(0);
+  }
+  50% {
+    box-shadow: 0 0 0 7px rgba(140, 207, 206, 0);
+    filter: blur(0.4px);
+  }
+}
+
+.search-row {
+  padding: 14px 28px 6px;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+#search {
+  width: 100%;
+  max-width: 480px;
+  background: var(--bg-raised);
+  color: var(--text);
+  font: inherit;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 9px 13px;
+  transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+
+#search::placeholder {
+  color: var(--text-muted);
+}
+
+#search:focus {
+  outline: none;
+  border-color: var(--forest);
+  background: var(--bg-elev);
+  box-shadow:
+    inset 0 0 0 1px rgba(122, 176, 157, 0.35),
+    0 0 0 4px var(--forest-mist);
+}
+
+/* Buttons ================================================== */
+
+.btn {
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 7px 13px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease,
+    transform 0.08s ease;
+  letter-spacing: 0.01em;
+}
+
+.btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn-ghost {
+  background: transparent;
+}
+
+.btn-primary {
+  background: var(--forest-dim);
+  border-color: rgba(122, 176, 157, 0.4);
+  color: var(--forest);
+}
+
+.btn-primary:hover {
+  background: rgba(122, 176, 157, 0.22);
+  border-color: var(--forest);
+  color: #a0c8ba;
+}
+
+#refresh-btn {
+  position: relative;
+}
+
+#refresh-btn.spinning {
+  animation: refreshSpin 420ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes refreshSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Dashboard grid =========================================== */
+
+.dashboard {
+  padding: 28px 28px 80px;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 18px;
+}
+
+/* Card ===================================================== */
+
+.card {
+  --tentacle: var(--driftwood);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 18px 16px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.22s ease, background 0.22s ease,
+    transform 0.22s cubic-bezier(0.2, 0.7, 0.2, 1),
+    box-shadow 0.22s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+/* Tentacle curve — replaces the old straight 3px stripe.
+   SVG drawn with currentColor so it inherits per-card --tentacle. */
+.card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  background-color: var(--tentacle);
+  opacity: 0.7;
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 120' preserveAspectRatio='none'><path d='M4 0 C1 20, 7 40, 4 60 S1 100, 4 120' fill='none' stroke='black' stroke-width='3' stroke-linecap='round'/></svg>");
+          mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 120' preserveAspectRatio='none'><path d='M4 0 C1 20, 7 40, 4 60 S1 100, 4 120' fill='none' stroke='black' stroke-width='3' stroke-linecap='round'/></svg>");
+  -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
+          mask-size: 100% 100%;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-elev);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lift);
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card-working {
+  border-color: rgba(140, 207, 206, 0.32);
+}
+
+.card-dead {
+  opacity: 0.5;
+}
+
+.card-stale {
+  border-style: dashed;
+  border-color: var(--amber-dim);
+}
+
+/* Ripple when SSE pushes a changed card. Soft turquoise fade across left edge. */
+.card.is-updated::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--turquoise);
+  border-radius: 3px 0 0 3px;
+  animation: cardRipple 1s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+  pointer-events: none;
+}
+
+@keyframes cardRipple {
+  0% {
+    opacity: 0.8;
+    transform: scaleY(0.4);
+    transform-origin: center;
+  }
+  40% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleY(1);
+  }
+}
+
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.card-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.tentacle-name {
+  margin: 0;
+  font-size: 15.5px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-meta {
+  display: inline-flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.pill {
+  font-size: 10.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  background: transparent;
+}
+
+.pill-team-lead {
+  color: var(--forest);
+  border-color: rgba(122, 176, 157, 0.4);
+  background: var(--forest-dim);
+}
+
+.pill-warn {
+  color: var(--amber);
+  border-color: var(--amber-dim);
+  background: rgba(212, 163, 115, 0.08);
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--driftwood);
+  flex-shrink: 0;
+  position: relative;
+}
+
+.status-dot.status-idle {
+  background: var(--forest);
+  box-shadow: 0 0 0 0 rgba(122, 176, 157, 0.3);
+}
+
+.status-dot.status-working {
+  background: var(--turquoise);
+  box-shadow: 0 0 0 0 rgba(140, 207, 206, 0.55);
+  animation: workingBreathe 2.2s ease-in-out infinite;
+}
+
+@keyframes workingBreathe {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(140, 207, 206, 0.5);
+    transform: scale(1);
+    filter: blur(0);
+  }
+  50% {
+    box-shadow: 0 0 0 7px rgba(140, 207, 206, 0);
+    transform: scale(1.18);
+    filter: blur(0.3px);
+  }
+}
+
+.status-dot.status-dead {
+  background: var(--driftwood);
+  opacity: 0.4;
+}
+
+.card-facts {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 20px;
+}
+
+.card-facts > div {
+  min-width: 0;
+}
+
+.card-facts dt {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+  margin-bottom: 3px;
+}
+
+.card-facts dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 12.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+
+.card-facts .age {
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.tail {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  background: var(--bg-tail);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  /* Fixed height so cards align row-to-row without jitter. */
+  height: 152px;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  position: relative;
+  mask-image: linear-gradient(to top, black 65%, rgba(0, 0, 0, 0.4));
+  -webkit-mask-image: linear-gradient(to top, black 65%, rgba(0, 0, 0, 0.4));
+}
+
+.tail-quiet {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  mask-image: none;
+  -webkit-mask-image: none;
+  background: transparent;
+  border-style: dashed;
+}
+
+.quiet-line {
+  font-family: var(--display);
+  font-style: italic;
+  color: var(--text-dim);
+  font-size: 13px;
+  letter-spacing: 0.01em;
+  font-variation-settings: "SOFT" 60;
+}
+
+.card-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+
+/* Empty & orphans ========================================== */
+
+.empty {
+  margin: 96px auto;
+  max-width: 460px;
+  text-align: center;
+  color: var(--text-dim);
+}
+
+.empty-glyph {
+  width: 84px;
+  height: 84px;
+  margin: 0 auto 18px;
+  color: var(--forest);
+  opacity: 0.85;
+}
+
+.empty-glyph svg {
+  width: 100%;
+  height: 100%;
+}
+
+.empty h2 {
+  margin: 0 0 10px;
+  font-family: var(--display);
+  font-size: 22px;
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  font-variation-settings: "SOFT" 80;
+}
+
+.empty p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+.empty .soft {
+  font-family: var(--display);
+  font-style: italic;
+  color: var(--driftwood);
+  font-size: 14.5px;
+  letter-spacing: 0.005em;
+}
+
+.orphans {
+  margin-top: 56px;
+  padding-top: 0;
+  border-top: 1px solid var(--border);
+}
+
+.orphans > summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 4px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-dim);
+}
+
+.orphans > summary::-webkit-details-marker {
+  display: none;
+}
+
+.orphans > summary::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-left: 5px solid var(--text-muted);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.18s ease;
+  flex-shrink: 0;
+}
+
+.orphans[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.orphans-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.orphans-label {
+  font-size: 12.5px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.orphans-hint {
+  font-family: var(--display);
+  font-style: italic;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  margin-left: auto;
+}
+
+.orphans .hint {
+  margin: 0 0 12px;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  max-width: 640px;
+}
+
+.orphans ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.orphans li {
+  color: var(--text-dim);
+  padding: 4px 0;
+}
+
+.orphans li strong {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* Pane expanded view ======================================= */
+
+.pane-view {
+  --tentacle: var(--forest);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 28px 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.scrollback {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.55;
+  background: var(--bg-tail);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--tentacle);
+  border-radius: var(--radius);
+  padding: 18px 22px;
+  margin: 0;
+  max-height: calc(100vh - 280px);
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+  font-variant-numeric: tabular-nums;
+}
+
+.scrollback::-webkit-scrollbar {
+  width: 10px;
+}
+
+.scrollback::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 999px;
+}
+
+.send-form {
+  position: sticky;
+  bottom: 16px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.4);
+}
+
+.send-form:focus-within {
+  border-color: var(--border-strong);
+  box-shadow:
+    0 10px 32px rgba(0, 0, 0, 0.4),
+    0 0 0 4px var(--forest-mist);
+}
+
+#send-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 10px 4px;
+  outline: none;
+}
+
+#send-input::placeholder {
+  color: var(--text-muted);
+}
+
+.quick {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.quick .btn-primary {
+  margin-left: auto;
+}
+
+/* Feedback toast ============================================ */
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translate(-50%, 20px);
+  padding: 10px 16px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 13px;
+  opacity: 0;
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(0.2, 0.7, 0.2, 1);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.toast.toast-show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.toast-error {
+  border-color: var(--amber-dim);
+  color: var(--amber);
+}
+
+/* Mobile / tablet =========================================== */
+
+@media (max-width: 720px) {
+  .app-header-inner {
+    padding: 12px 16px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .meta {
+    gap: 8px;
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .stat-pill {
+    padding: 4px 10px;
+  }
+  .dashboard,
+  .pane-view {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .search-row {
+    padding: 12px 16px 6px;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .btn {
+    padding: 10px 14px;
+    min-height: 44px;
+  }
+  .btn-key {
+    padding: 8px 12px;
+    min-height: 38px;
+    min-width: 44px;
+  }
+  body::before {
+    animation-duration: 120s;
+  }
+  .hero {
+    padding: 18px 18px 16px;
+  }
+  .hero-head {
+    grid-template-columns: auto 1fr;
+    gap: 14px;
+  }
+  .hero-glyph {
+    width: 44px;
+    height: 44px;
+  }
+  .hero-name {
+    font-size: 22px;
+  }
+  .hero-open {
+    grid-column: 1 / -1;
+    justify-self: stretch;
+    text-align: center;
+  }
+  .hero-tail {
+    height: 160px;
+  }
+  .arms-layer {
+    left: 12px;
+    right: 12px;
+    width: calc(100% - 24px);
+    height: 40px;
+    bottom: -22px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::before,
+  .status-dot.status-working,
+  .refresh-stat .stat-value::before,
+  .card.is-updated::after,
+  .card.is-mentioned,
+  .hero-section.is-flowing .arms-layer .arm,
+  #refresh-btn.spinning {
+    animation: none !important;
+  }
+  .card,
+  .hero {
+    transition: none;
+  }
+}
+
+/* Hero (team-lead) ========================================= */
+
+.hero-section {
+  position: relative;
+  margin-bottom: 28px;
+}
+
+.hero {
+  --tentacle: var(--forest);
+  position: relative;
+  background:
+    radial-gradient(ellipse 65% 80% at 100% 0%, rgba(140, 207, 206, 0.07), transparent 60%),
+    var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 22px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 6px 32px -16px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease, transform 0.4s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background-color: var(--tentacle);
+  opacity: 0.85;
+  border-radius: 4px 0 0 4px;
+}
+
+.hero-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+}
+
+.hero-glyph {
+  width: 56px;
+  height: 56px;
+  color: var(--forest);
+  flex-shrink: 0;
+}
+
+.hero-glyph svg {
+  width: 100%;
+  height: 100%;
+}
+
+.hero-titles {
+  min-width: 0;
+}
+
+.hero-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.hero-name {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  font-variation-settings: "SOFT" 50;
+  line-height: 1.1;
+}
+
+.hero-sub {
+  margin-top: 5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--text-dim);
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.hero-dot {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.hero-open {
+  align-self: center;
+}
+
+.hero-tail {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  background: var(--bg-tail);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  height: 220px;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  mask-image: linear-gradient(to top, black 70%, rgba(0, 0, 0, 0.45));
+  -webkit-mask-image: linear-gradient(to top, black 70%, rgba(0, 0, 0, 0.45));
+}
+
+/* Arms layer — three SVG curves emanating from the bottom of the hero into
+   the grid. Decorative; sits behind the cards. */
+.arms-layer {
+  position: absolute;
+  left: 28px;
+  right: 28px;
+  width: calc(100% - 56px);
+  bottom: -32px;
+  height: 56px;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.9;
+  display: block;
+}
+
+.arms-layer .arm {
+  stroke-dasharray: 3 7;
+  stroke-dashoffset: 0;
+  opacity: 0.5;
+  transition: opacity 0.4s ease, stroke 0.4s ease;
+}
+
+/* Amber flow when team-lead is working — slow drift downstream as if a command
+   is descending toward the tentacles. */
+.hero-section.is-flowing .arms-layer .arm {
+  stroke: rgba(212, 163, 115, 0.55);
+  opacity: 0.9;
+  animation: armsFlow 3s linear infinite;
+}
+
+@keyframes armsFlow {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: -20;
+  }
+}
+
+/* Recently-mentioned ring on tentacle cards =============== */
+
+.card.is-mentioned {
+  animation: mentionRing 3s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+}
+
+@keyframes mentionRing {
+  0% {
+    box-shadow:
+      var(--shadow),
+      0 0 0 0 rgba(140, 207, 206, 0.55);
+    border-color: var(--turquoise);
+  }
+  18% {
+    box-shadow:
+      var(--shadow),
+      0 0 0 5px rgba(140, 207, 206, 0.18);
+    border-color: var(--turquoise);
+  }
+  100% {
+    box-shadow:
+      var(--shadow),
+      0 0 0 0 rgba(140, 207, 206, 0);
+    border-color: var(--border);
+  }
+}
+
+/* Pane special-key controls =============================== */
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+  border-top: 1px dashed var(--border);
+}
+
+.control-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+
+.btn-key {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  background: var(--bg-tail);
+  border-color: rgba(140, 207, 206, 0.18);
+  color: var(--text);
+  min-width: 38px;
+}
+
+.btn-key:hover {
+  background: rgba(140, 207, 206, 0.12);
+  border-color: var(--turquoise);
+  color: var(--turquoise);
+}
+
+.empty-compact {
+  margin: 56px auto;
+  padding: 28px;
+}
+
+.empty-compact h2 {
+  font-size: 18px;
+}
+
+/* Focus ring =============================================== */
+
+:focus-visible {
+  outline: 2px solid var(--forest);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Hide orphan cards when filtered out */
+.card.is-hidden {
+  display: none;
+}
+
+/* Spawn button in header =================================== */
+
+#spawn-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.spawn-glyph {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* Card close (shutdown) button ============================= */
+
+.card-close {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  margin-left: 4px;
+}
+
+.card-close:hover {
+  color: var(--amber);
+  background: rgba(212, 163, 115, 0.08);
+  border-color: rgba(212, 163, 115, 0.35);
+}
+
+.card-close:focus-visible {
+  color: var(--amber);
+}
+
+/* Modal ===================================================== */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 14, 12, 0.72);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.modal-backdrop.is-open {
+  opacity: 1;
+}
+
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 80px -24px rgba(0, 0, 0, 0.7);
+  width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(8px);
+  transition: transform 0.18s ease;
+}
+
+.modal-backdrop.is-open .modal {
+  transform: translateY(0);
+}
+
+.modal-compact {
+  width: min(440px, 100%);
+}
+
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-head h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  font-variation-settings: "SOFT" 50;
+}
+
+.modal-close {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.modal-close:hover {
+  color: var(--text);
+  background: var(--bg-tail);
+}
+
+.modal-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.modal-body label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+
+.field-hint {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-style: italic;
+  font-family: var(--display);
+  font-variation-settings: "SOFT" 60;
+}
+
+.field-error {
+  font-size: 12.5px;
+  color: var(--amber);
+  font-family: var(--mono);
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in oklab, var(--amber) 35%, transparent);
+  background: color-mix(in oklab, var(--amber) 10%, transparent);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.modal-body input,
+.modal-body textarea {
+  appearance: none;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg-tail);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 9px 11px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+.modal-body input:focus,
+.modal-body textarea:focus {
+  border-color: var(--turquoise);
+  box-shadow: 0 0 0 3px rgba(140, 207, 206, 0.1);
+}
+
+.modal-body p.soft {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.modal-body code.mono {
+  background: var(--bg-tail);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.modal-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 18px;
+  border-top: 1px solid var(--border);
+}
+
+.btn-danger {
+  appearance: none;
+  background: rgba(200, 138, 125, 0.1);
+  color: #E3A89C;
+  border: 1px solid rgba(200, 138, 125, 0.4);
+  border-radius: var(--radius-sm);
+  padding: 7px 14px;
+  font-family: var(--ui);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-danger:hover {
+  background: rgba(200, 138, 125, 0.2);
+  border-color: rgba(200, 138, 125, 0.6);
+  color: #EFC0B6;
+}
+
+.btn-danger:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+/* Highlighted mode key (Shift+Tab — Claude Code mode cycle) */
+.btn-key-accent {
+  border-color: rgba(140, 207, 206, 0.45) !important;
+  color: var(--turquoise) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop,
+  .modal {
+    transition: none;
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+// octopus — team layer for Claude Code.
+// Subcommands dispatch to ./cli/*.ts. Flags are parsed locally in each
+// subcommand to keep the surface tiny and avoid a flag-parser dependency.
+
+import { runHelp } from "./cli/help.ts";
+import { runInit } from "./cli/init.ts";
+import { runLaunch } from "./cli/launch.ts";
+import { runSend } from "./cli/send.ts";
+import { runSpawn } from "./cli/spawn.ts";
+import { runUi } from "./cli/ui.ts";
+
+const VERSION = "0.1.0";
+
+async function main(): Promise<void> {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    runHelp();
+    return;
+  }
+  if (command === "version" || command === "--version" || command === "-v") {
+    console.log(VERSION);
+    return;
+  }
+
+  switch (command) {
+    case "init":
+      await runInit(rest);
+      return;
+    case "launch":
+      await runLaunch(rest);
+      return;
+    case "ui":
+      await runUi(rest);
+      return;
+    case "send":
+      await runSend(rest);
+      return;
+    case "spawn":
+      await runSpawn(rest);
+      return;
+    default:
+      console.error(`unknown command: ${command}`);
+      console.error(`run \`octopus help\` for usage.`);
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -1,0 +1,33 @@
+// Tiny flag parser — just enough for the handful of long flags we accept.
+// Anything unrecognized is left in the positional list so subcommands can
+// pass-through arbitrary tail args (e.g. `octopus send /reload-plugins`).
+
+export interface ParsedFlags {
+  flags: Record<string, string | true>;
+  positional: string[];
+}
+
+export function parseFlags(args: string[], known: string[]): ParsedFlags {
+  const flags: Record<string, string | true> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("--")) {
+      const name = a.slice(2);
+      if (!known.includes(name)) {
+        positional.push(a);
+        continue;
+      }
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[name] = next;
+        i++;
+      } else {
+        flags[name] = true;
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,42 @@
+export function runHelp(): void {
+  console.log(`octopus — team layer for Claude Code
+
+A spawn / observe / coordinate harness for Claude Code teammates ("tentacles")
+in any repo. One central session (the team-lead) holds the conversation;
+tentacles do the focused work in their own panes.
+
+Commands:
+  init [--team <name>]
+      Bootstrap the current repo: writes the spawn/report slash commands and
+      the tentacle/reviewer agent definitions into .claude/, and ensures
+      CLAUDE.md links the octopus conventions snippet.
+
+  launch [--team <name>] [--cwd <path>] [--session <name>]
+      Start (or attach to) a tmux session running Claude Code as the team-lead.
+      Defaults: team "octopus", cwd "$PWD", session "octopus".
+
+  ui [--team <name>] [--port 6061] [--host 127.0.0.1]
+      Start the web dashboard. Loopback by default; pass --host 0.0.0.0 to
+      expose it on the LAN / Tailscale.
+
+  send <text...> [--session <name>]
+      Send keystrokes to the team-lead's tmux session via tmux send-keys.
+
+  spawn <name> <cwd> <prompt...> [--session <name>]
+      Type \`/spawn <name> <cwd> <prompt>\` into the team-lead's pane.
+      Convenience for firing the slash command from a terminal.
+
+  help, --help, -h     Show this help
+  version, --version   Show version
+
+Environment:
+  OCTOPUS_TEAM            Override default team name ("octopus")
+  OCTOPUS_TEAM_CONFIG     Absolute path to a team config.json (skips lookup)
+  OCTOPUS_UI_PORT         UI port (default 6061)
+  OCTOPUS_UI_HOST         UI bind host (default 127.0.0.1)
+  OCTOPUS_UI_POLL_MS      Snapshot interval in ms (default 2000)
+  OCTOPUS_SPAWN_TARGETS   Colon-separated absolute paths for spawn datalist
+
+Learn more: https://github.com/ParachuteComputer/octopus
+`);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -11,9 +11,11 @@ Commands:
       the tentacle/reviewer agent definitions into .claude/, and ensures
       CLAUDE.md links the octopus conventions snippet.
 
-  launch [--team <name>] [--cwd <path>] [--session <name>]
+  launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>] [--no-skip-permissions]
       Start (or attach to) a tmux session running Claude Code as the team-lead.
-      Defaults: team "octopus", cwd "$PWD", session "octopus".
+      Defaults: team "octopus", cwd "$PWD", session = team name. Passes
+      --dangerously-skip-permissions to claude by default; opt out with
+      --no-skip-permissions or OCTOPUS_SKIP_PERMISSIONS=false.
 
   ui [--team <name>] [--port 6061] [--host 127.0.0.1]
       Start the web dashboard. Loopback by default; pass --host 0.0.0.0 to

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseFlags } from "./flags.ts";
+import { resolveTemplatesDir } from "../paths.ts";
+
+const TEMPLATE_FILES: { src: string; dest: string }[] = [
+  { src: "spawn.md",    dest: ".claude/commands/spawn.md" },
+  { src: "report.md",   dest: ".claude/commands/report.md" },
+  { src: "tentacle.md", dest: ".claude/agents/tentacle.md" },
+  { src: "reviewer.md", dest: ".claude/agents/reviewer.md" },
+  { src: "octopus.md",  dest: ".claude/octopus.md" },
+];
+
+const CLAUDE_MD_LINK = "@.claude/octopus.md";
+
+export async function runInit(argv: string[]): Promise<void> {
+  const { flags } = parseFlags(argv, ["team", "cwd"]);
+  const team = (flags.team as string) ?? "octopus";
+  const targetCwd = resolve((flags.cwd as string) ?? process.cwd());
+  const templatesDir = resolveTemplatesDir();
+
+  if (!existsSync(templatesDir)) {
+    throw new Error(`templates directory not found at ${templatesDir} — package install may be incomplete`);
+  }
+
+  console.log(`octopus init — team "${team}" in ${targetCwd}`);
+  for (const { src, dest } of TEMPLATE_FILES) {
+    const srcPath = join(templatesDir, src);
+    const destPath = join(targetCwd, dest);
+    mkdirSync(join(destPath, ".."), { recursive: true });
+    writeFileSync(destPath, readFileSync(srcPath, "utf8"));
+    console.log(`  wrote ${dest}`);
+  }
+
+  ensureClaudeMdLink(targetCwd);
+  console.log(`done. next: \`octopus launch\` to start the team-lead session.`);
+}
+
+function ensureClaudeMdLink(targetCwd: string): void {
+  const path = join(targetCwd, "CLAUDE.md");
+  if (!existsSync(path)) {
+    const body =
+      `${CLAUDE_MD_LINK}\n\n` +
+      `<!-- Octopus team conventions are loaded above. Add project-specific\n` +
+      `     guidance for tentacles and the team-lead below. -->\n`;
+    writeFileSync(path, body);
+    console.log(`  created CLAUDE.md with octopus link`);
+    return;
+  }
+  const existing = readFileSync(path, "utf8");
+  if (existing.includes(CLAUDE_MD_LINK)) {
+    console.log(`  CLAUDE.md already links octopus conventions — left untouched`);
+    return;
+  }
+  // Prepend the link as the first line so Claude Code auto-loads the snippet.
+  writeFileSync(path, `${CLAUDE_MD_LINK}\n\n${existing}`);
+  console.log(`  prepended ${CLAUDE_MD_LINK} to CLAUDE.md`);
+}

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseFlags } from "./flags.ts";
+import { tmuxHasSession, which } from "./tmux.ts";
+
+export async function runLaunch(argv: string[]): Promise<void> {
+  const { flags } = parseFlags(argv, ["team", "cwd", "session", "model"]);
+  const team = (flags.team as string) ?? process.env.OCTOPUS_TEAM ?? "octopus";
+  const cwd = resolve((flags.cwd as string) ?? process.cwd());
+  const session = (flags.session as string) ?? team;
+  const model = (flags.model as string) ?? "";
+
+  if (!which("tmux")) {
+    console.error("error: tmux is not installed or not on PATH (try `brew install tmux`).");
+    process.exit(1);
+  }
+  if (!which("claude")) {
+    console.error("error: `claude` (Claude Code CLI) is not on PATH.");
+    console.error("Install Claude Code first: https://docs.claude.com/claude-code");
+    process.exit(1);
+  }
+  if (!existsSync(cwd)) {
+    console.error(`error: cwd does not exist: ${cwd}`);
+    process.exit(1);
+  }
+
+  if (tmuxHasSession(session)) {
+    console.log(`attaching to existing tmux session "${session}"`);
+  } else {
+    const claudeArgs = [
+      "tmux",
+      "new-session",
+      "-d",
+      "-s",
+      session,
+      "-c",
+      cwd,
+      "claude",
+      "--dangerously-skip-permissions",
+    ];
+    if (model) claudeArgs.push("--model", model);
+    const create = Bun.spawnSync(claudeArgs, { stdout: "inherit", stderr: "inherit" });
+    if (create.exitCode !== 0) {
+      console.error("error: failed to create tmux session.");
+      process.exit(create.exitCode ?? 1);
+    }
+    console.log(`started octopus team "${team}" in tmux session "${session}" (cwd: ${cwd})`);
+  }
+
+  const insideTmux = !!process.env.TMUX;
+  const attachCmd = insideTmux
+    ? ["tmux", "switch-client", "-t", session]
+    : ["tmux", "attach-session", "-t", session];
+  const attach = Bun.spawn(attachCmd, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await attach.exited;
+  process.exit(code);
+}

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -4,11 +4,17 @@ import { parseFlags } from "./flags.ts";
 import { tmuxHasSession, which } from "./tmux.ts";
 
 export async function runLaunch(argv: string[]): Promise<void> {
-  const { flags } = parseFlags(argv, ["team", "cwd", "session", "model"]);
+  const { flags } = parseFlags(argv, ["team", "cwd", "session", "model", "no-skip-permissions"]);
   const team = (flags.team as string) ?? process.env.OCTOPUS_TEAM ?? "octopus";
   const cwd = resolve((flags.cwd as string) ?? process.cwd());
   const session = (flags.session as string) ?? team;
   const model = (flags.model as string) ?? "";
+  // Default: pass --dangerously-skip-permissions so the team-lead can dispatch
+  // freely. Opt out via --no-skip-permissions or OCTOPUS_SKIP_PERMISSIONS=false
+  // for shared / less-trusted environments.
+  const skipPermissions =
+    !flags["no-skip-permissions"] &&
+    process.env.OCTOPUS_SKIP_PERMISSIONS !== "false";
 
   if (!which("tmux")) {
     console.error("error: tmux is not installed or not on PATH (try `brew install tmux`).");
@@ -35,9 +41,11 @@ export async function runLaunch(argv: string[]): Promise<void> {
       session,
       "-c",
       cwd,
+      "-e",
+      `OCTOPUS_TEAM=${team}`,
       "claude",
-      "--dangerously-skip-permissions",
     ];
+    if (skipPermissions) claudeArgs.push("--dangerously-skip-permissions");
     if (model) claudeArgs.push("--model", model);
     const create = Bun.spawnSync(claudeArgs, { stdout: "inherit", stderr: "inherit" });
     if (create.exitCode !== 0) {

--- a/src/cli/send.ts
+++ b/src/cli/send.ts
@@ -1,0 +1,34 @@
+import { parseFlags } from "./flags.ts";
+import { tmuxHasSession, tmuxSendKeys, which } from "./tmux.ts";
+
+export async function runSend(argv: string[]): Promise<void> {
+  const { flags, positional } = parseFlags(argv, ["session", "team"]);
+  if (positional.length === 0) {
+    console.error("error: send requires at least one argument");
+    console.error("usage: octopus send <text...> [--session <name>]");
+    process.exit(1);
+  }
+  if (!which("tmux")) {
+    console.error("error: tmux is not installed or not on PATH.");
+    process.exit(1);
+  }
+  const session =
+    (flags.session as string) ??
+    (flags.team as string) ??
+    process.env.OCTOPUS_TEAM ??
+    "octopus";
+
+  if (!tmuxHasSession(session)) {
+    console.error(`error: no running tmux session "${session}".`);
+    console.error("Run `octopus launch` first.");
+    process.exit(1);
+  }
+
+  const text = positional.join(" ");
+  const code = tmuxSendKeys(session, text, true);
+  if (code !== 0) {
+    console.error(`error: tmux send-keys failed (exit ${code}).`);
+    process.exit(code);
+  }
+  console.log(`sent to ${session}: ${text}`);
+}

--- a/src/cli/spawn.ts
+++ b/src/cli/spawn.ts
@@ -1,0 +1,51 @@
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseFlags } from "./flags.ts";
+import { tmuxHasSession, tmuxSendKeys, which } from "./tmux.ts";
+
+const NAME_RX = /^[a-z][a-z0-9-]{1,30}$/;
+
+export async function runSpawn(argv: string[]): Promise<void> {
+  const { flags, positional } = parseFlags(argv, ["session", "team"]);
+  const [name, cwdRaw, ...promptParts] = positional;
+
+  if (!name || !cwdRaw) {
+    console.error("error: spawn requires <name> <cwd> [prompt...]");
+    console.error("usage: octopus spawn <name> <cwd> <prompt...>");
+    process.exit(1);
+  }
+  if (!NAME_RX.test(name)) {
+    console.error(`error: invalid name "${name}" (lowercase letters/digits/dashes, 2-31 chars, must start with letter)`);
+    process.exit(1);
+  }
+  const cwd = resolve(cwdRaw);
+  if (!existsSync(cwd) || !statSync(cwd).isDirectory()) {
+    console.error(`error: cwd does not exist or is not a directory: ${cwd}`);
+    process.exit(1);
+  }
+  if (!which("tmux")) {
+    console.error("error: tmux is not installed or not on PATH.");
+    process.exit(1);
+  }
+  const session =
+    (flags.session as string) ??
+    (flags.team as string) ??
+    process.env.OCTOPUS_TEAM ??
+    "octopus";
+  if (!tmuxHasSession(session)) {
+    console.error(`error: no running tmux session "${session}".`);
+    console.error("Run `octopus launch` first.");
+    process.exit(1);
+  }
+
+  // Slash-command $ARGUMENTS is single-line; flatten any whitespace so the tty
+  // doesn't submit early. Long briefs should be sent as a follow-up message.
+  const prompt = promptParts.join(" ").replace(/\s+/g, " ").trim();
+  const command = `/spawn ${name} ${cwd}${prompt ? ` ${prompt}` : ""}`;
+  const code = tmuxSendKeys(session, command, true);
+  if (code !== 0) {
+    console.error(`error: tmux send-keys failed (exit ${code}).`);
+    process.exit(code);
+  }
+  console.log(`typed to ${session}: /spawn ${name} …`);
+}

--- a/src/cli/tmux.ts
+++ b/src/cli/tmux.ts
@@ -1,0 +1,30 @@
+// Thin process helpers for the CLI. Kept separate from src/ui/tmux.ts so the
+// CLI doesn't need to import the streaming/snapshot machinery just to shell
+// out to tmux send-keys.
+
+export function which(cmd: string): boolean {
+  const r = Bun.spawnSync(["which", cmd], { stdout: "ignore", stderr: "ignore" });
+  return r.exitCode === 0;
+}
+
+export function tmuxHasSession(name: string): boolean {
+  const r = Bun.spawnSync(["tmux", "has-session", "-t", name], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return r.exitCode === 0;
+}
+
+export function tmuxSendKeys(target: string, text: string, withEnter = true): number {
+  const args = ["tmux", "send-keys", "-t", target, "--", text];
+  const r = Bun.spawnSync(args, { stdout: "inherit", stderr: "inherit" });
+  if (r.exitCode !== 0) return r.exitCode ?? 1;
+  if (withEnter) {
+    const e = Bun.spawnSync(["tmux", "send-keys", "-t", target, "Enter"], {
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    return e.exitCode ?? 0;
+  }
+  return 0;
+}

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,0 +1,19 @@
+import { parseFlags } from "./flags.ts";
+
+export async function runUi(argv: string[]): Promise<void> {
+  const { flags } = parseFlags(argv, ["team", "team-config", "port", "host", "poll-ms"]);
+
+  // Push CLI flags into env so the embedded server picks them up — keeps the
+  // server module env-driven (it doesn't need to know the CLI exists).
+  if (flags["team"]) process.env.OCTOPUS_TEAM = String(flags["team"]);
+  if (flags["team-config"]) process.env.OCTOPUS_TEAM_CONFIG = String(flags["team-config"]);
+  if (flags["port"]) process.env.OCTOPUS_UI_PORT = String(flags["port"]);
+  if (flags["host"]) process.env.OCTOPUS_UI_HOST = String(flags["host"]);
+  if (flags["poll-ms"]) process.env.OCTOPUS_UI_POLL_MS = String(flags["poll-ms"]);
+
+  const { app } = await import("../ui/server.tsx");
+  const port = Number(process.env.OCTOPUS_UI_PORT ?? 6061);
+  const host = process.env.OCTOPUS_UI_HOST ?? "127.0.0.1";
+  console.log(`🐙 octopus → http://${host}:${port}`);
+  Bun.serve({ fetch: app.fetch, port, hostname: host, idleTimeout: 0 });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,14 @@
+// Re-exports for the team-config layer. The actual loader lives in src/ui/state.ts
+// (where it's used by the snapshot pipeline). This module gives the CLI a
+// stable import surface that doesn't reach into the UI internals.
+export {
+  getConfigPath,
+  loadConfig,
+  setConfigPath,
+  type ConfigMember,
+  type TeamConfig,
+} from "./ui/state.ts";
+export {
+  requireTeamConfig,
+  resolveTeamConfigPath,
+} from "./paths.ts";

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Path helpers shared between the CLI and the embedded UI server.
+
+/**
+ * Resolve the team config path using the priority chain:
+ *   1. explicit override (CLI flag / OCTOPUS_TEAM_CONFIG)
+ *   2. project-local: <cwd>/.claude/teams/<team>/config.json
+ *   3. home-dir:      ~/.claude/teams/<team>/config.json
+ *
+ * Returns the first path that exists, or the home-dir path as the last-resort
+ * default. Callers that need to fail loudly should call requireTeamConfig().
+ */
+export function resolveTeamConfigPath(team: string, override?: string): string {
+  if (override && override.trim()) return resolve(override);
+  const projectLocal = join(process.cwd(), ".claude", "teams", team, "config.json");
+  if (existsSync(projectLocal)) return projectLocal;
+  return join(homedir(), ".claude", "teams", team, "config.json");
+}
+
+export function requireTeamConfig(team: string, override?: string): string {
+  const path = resolveTeamConfigPath(team, override);
+  if (!existsSync(path)) {
+    throw new Error(
+      `No octopus team config found for team "${team}". Looked at:\n` +
+        `  • ${join(process.cwd(), ".claude", "teams", team, "config.json")}\n` +
+        `  • ${join(homedir(), ".claude", "teams", team, "config.json")}\n` +
+        `Run \`octopus init\` in this repo, then \`octopus launch\`.`,
+    );
+  }
+  return path;
+}
+
+/**
+ * Locate the `public/` directory that ships with the package. We walk up from
+ * this file's directory looking for a sibling `public/` — works for both the
+ * source tree (src/paths.ts → ../public) and the built dist tree
+ * (dist/paths.js → ../public).
+ */
+export function resolvePublicDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, "..", "public"),
+    join(here, "..", "..", "public"),
+    join(here, "public"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(join(c, "styles.css"))) return resolve(c);
+  }
+  // Fall back to cwd/public so tests run from the source tree still find it.
+  return resolve(join(process.cwd(), "public"));
+}
+
+export function resolveTemplatesDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, "..", "templates"),
+    join(here, "..", "..", "templates"),
+    join(here, "templates"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(join(c, "spawn.md"))) return resolve(c);
+  }
+  return resolve(join(process.cwd(), "templates"));
+}
+
+/**
+ * Spawn-target roots feed the spawn modal's cwd datalist suggestions. Override
+ * with OCTOPUS_SPAWN_TARGETS (colon-separated absolute paths). Defaults to the
+ * current working directory and its parent — sensible "siblings of this repo".
+ */
+export function resolveSpawnTargetRoots(): string[] {
+  const env = process.env.OCTOPUS_SPAWN_TARGETS;
+  if (env && env.trim()) {
+    return env
+      .split(":")
+      .map((p) => p.trim())
+      .filter((p) => p.startsWith("/"))
+      .map((p) => resolve(p));
+  }
+  const cwd = process.cwd();
+  return [cwd, resolve(cwd, "..")];
+}

--- a/src/ui/colors.ts
+++ b/src/ui/colors.ts
@@ -1,0 +1,20 @@
+// Per-tentacle colors, tuned to sit harmonious against Parachute's forest-dark bg.
+// Each hue desaturated ~15-20% from the original so they feel earthy rather than
+// neon. Green is literally nightForest; orange matches the stale-amber.
+export const TENTACLE_COLORS: Record<string, string> = {
+  blue: "#8AA6BF",    // dusty steel
+  yellow: "#D4BC7E",  // soft warm gold
+  purple: "#B09AC7",  // dusty lilac
+  orange: "#D4A373",  // warm amber (matches --amber)
+  cyan: "#8CCFCE",    // nightTurquoise
+  green: "#7AB09D",   // nightForest
+  pink: "#C9A0AA",    // dusty rose
+  red: "#C88A7D",     // muted terracotta
+  teal: "#6FA5A0",    // softer teal
+  slate: "#9B9590",   // driftwood
+};
+
+export function colorFor(name: string | undefined): string {
+  if (!name) return TENTACLE_COLORS.slate;
+  return TENTACLE_COLORS[name] ?? TENTACLE_COLORS.slate;
+}

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -1,0 +1,21 @@
+export function formatAge(ms: number | null): string {
+  if (ms === null) return "—";
+  const s = Math.round(ms / 1000);
+  if (s < 2) return "just now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+export function formatJoinedAt(ms: number): string {
+  const d = new Date(ms);
+  const now = new Date();
+  const sameDay = d.toDateString() === now.toDateString();
+  const time = d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  if (sameDay) return `today · ${time}`;
+  const date = d.toLocaleDateString([], { month: "short", day: "numeric" });
+  return `${date} · ${time}`;
+}

--- a/src/ui/render.tsx
+++ b/src/ui/render.tsx
@@ -1,0 +1,597 @@
+/** @jsxImportSource hono/jsx */
+import type { Snapshot, Tentacle } from "./state.ts";
+import { colorFor } from "./colors.ts";
+import { formatAge, formatJoinedAt } from "./format.ts";
+
+interface LayoutProps {
+  title: string;
+  children: any;
+}
+
+function Layout({ title, children }: LayoutProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#0f1715" />
+        <title>{title}</title>
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link rel="preconnect" href="https://rsms.me/" />
+        <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,500..700;1,500..700&family=JetBrains+Mono:wght@400;500&display=swap"
+        />
+        <link rel="stylesheet" href="/styles.css" />
+      </head>
+      <body data-page={title}>{children}</body>
+    </html>
+  );
+}
+
+// Abstract octopus glyph — soft-geometric, stroked in currentColor.
+function OctopusGlyph() {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path
+        d="M20 26 C20 16, 26 10, 32 10 S44 16, 44 26 V30 C44 32, 42 34, 40 34 H24 C22 34, 20 32, 20 30 Z"
+        stroke="currentColor"
+        stroke-width="2.4"
+        stroke-linejoin="round"
+      />
+      <circle cx="27.5" cy="23" r="1.4" fill="currentColor" />
+      <circle cx="36.5" cy="23" r="1.4" fill="currentColor" />
+      <path d="M23 34 C21 42, 15 46, 18 56" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" />
+      <path d="M30 34 C31 42, 26 50, 30 58" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" />
+      <path d="M34 34 C33 42, 38 50, 34 58" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" />
+      <path d="M41 34 C43 42, 49 46, 46 56" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" />
+    </svg>
+  );
+}
+
+function ParachuteGlyph() {
+  return (
+    <svg viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M12 50 C12 28, 28 14, 48 14 S84 28, 84 50" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" />
+      <path d="M12 50 Q30 44 48 50 T84 50" stroke="currentColor" stroke-width="1.3" opacity="0.55" />
+      <path d="M30 18 V50" stroke="currentColor" stroke-width="1.1" opacity="0.5" />
+      <path d="M48 14 V50" stroke="currentColor" stroke-width="1.1" opacity="0.5" />
+      <path d="M66 18 V50" stroke="currentColor" stroke-width="1.1" opacity="0.5" />
+      <path
+        d="M14 50 L44 78 M30 50 L46 78 M48 50 L48 80 M66 50 L50 78 M82 50 L52 78"
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        opacity="0.75"
+      />
+      <circle cx="48" cy="84" r="4" stroke="currentColor" stroke-width="1.8" />
+    </svg>
+  );
+}
+
+// Three-arm SVG flowing from the bottom of the hero card down into the grid.
+// Decorative — sits behind the cards and never catches clicks. The amber-glow
+// `is-flowing` state is added by the client when team-lead is working.
+function ArmsLayer() {
+  return (
+    <svg
+      class="arms-layer"
+      viewBox="0 0 1200 120"
+      preserveAspectRatio="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id="arm-gradient" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="rgba(122,176,157,0.32)" />
+          <stop offset="100%" stop-color="rgba(122,176,157,0)" />
+        </linearGradient>
+      </defs>
+      <path
+        class="arm arm-l"
+        d="M380 0 C 380 40, 240 60, 200 120"
+        stroke="url(#arm-gradient)"
+        fill="none"
+        stroke-width="1.4"
+        stroke-linecap="round"
+      />
+      <path
+        class="arm arm-c"
+        d="M600 0 C 600 50, 600 70, 600 120"
+        stroke="url(#arm-gradient)"
+        fill="none"
+        stroke-width="1.6"
+        stroke-linecap="round"
+      />
+      <path
+        class="arm arm-r"
+        d="M820 0 C 820 40, 960 60, 1000 120"
+        stroke="url(#arm-gradient)"
+        fill="none"
+        stroke-width="1.4"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}
+
+function Header({ snap }: { snap: Snapshot }) {
+  const alive = snap.tentacles.filter((t) => t.status !== "dead").length;
+  return (
+    <header class="app-header">
+      <div class="app-header-inner">
+        <div class="brand">
+          <span class="brand-glyph" aria-hidden="true">
+            <OctopusGlyph />
+          </span>
+          <span class="brand-name">Octopus</span>
+          <span class="brand-team">/ {snap.team}</span>
+        </div>
+        <div class="meta">
+          <span class="stat-pill" data-stat="alive">
+            <span class="stat-value">{alive}</span>
+            <span class="stat-label">alive</span>
+          </span>
+          <span class="stat-pill" data-stat="roster">
+            <span class="stat-value">{snap.totalMembers}</span>
+            <span class="stat-label">roster</span>
+          </span>
+          <span class="stat-pill" data-stat="panes">
+            <span class="stat-value">{snap.livePanes}</span>
+            <span class="stat-label">panes</span>
+          </span>
+          <span class="stat-pill refresh-stat" data-stat="stream">
+            <span class="stat-value" id="refresh-indicator">
+              live
+            </span>
+            <span class="stat-label">stream</span>
+          </span>
+          <button class="btn btn-ghost" id="refresh-btn" title="Refresh (r)">
+            refresh
+          </button>
+          <button class="btn btn-primary" id="spawn-btn" title="Spawn a new tentacle (n)">
+            <span class="spawn-glyph" aria-hidden="true">🐙</span>
+            <span>spawn</span>
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function SpawnModal() {
+  return (
+    <div class="modal-backdrop" id="spawn-modal" hidden>
+      <div class="modal" role="dialog" aria-labelledby="spawn-title" aria-modal="true">
+        <header class="modal-head">
+          <h2 id="spawn-title">Spawn a tentacle</h2>
+          <button type="button" class="modal-close" data-modal-close="spawn-modal" aria-label="close">
+            ×
+          </button>
+        </header>
+        <form id="spawn-form" class="modal-body">
+          <label>
+            <span class="field-label">Name</span>
+            <input
+              type="text"
+              name="name"
+              class="mono"
+              required
+              pattern="[a-z][a-z0-9\-]{1,30}"
+              placeholder="parachute-foo"
+              autocomplete="off"
+              spellcheck={false}
+            />
+            <span class="field-hint">lowercase, digits, dashes; starts with a letter</span>
+          </label>
+          <label>
+            <span class="field-label">Working directory</span>
+            <input
+              type="text"
+              name="cwd"
+              class="mono"
+              list="spawn-target-list"
+              required
+              placeholder="/Users/you/UnforcedAGI/Code/ParachuteComputer/…"
+              autocomplete="off"
+              spellcheck={false}
+            />
+            <datalist id="spawn-target-list" />
+          </label>
+          <label>
+            <span class="field-label">Clone from (optional)</span>
+            <input
+              type="text"
+              name="cloneUrl"
+              class="mono"
+              placeholder="https://github.com/org/repo.git"
+              autocomplete="off"
+              spellcheck={false}
+            />
+            <span class="field-hint">only used if the working directory doesn't exist yet</span>
+          </label>
+          <label>
+            <span class="field-label">Initial brief</span>
+            <textarea
+              name="prompt"
+              class="mono"
+              rows={6}
+              placeholder="What should this tentacle do first?"
+              spellcheck={false}
+            />
+            <span class="field-hint">team-lead will pick up this request and spawn the tentacle</span>
+          </label>
+          <p class="field-error" id="spawn-error" hidden></p>
+          <footer class="modal-foot">
+            <button type="button" class="btn btn-ghost" data-modal-close="spawn-modal">
+              cancel
+            </button>
+            <button type="submit" class="btn btn-primary">
+              spawn
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ShutdownModal() {
+  return (
+    <div class="modal-backdrop" id="shutdown-modal" hidden>
+      <div class="modal modal-compact" role="dialog" aria-labelledby="shutdown-title" aria-modal="true">
+        <header class="modal-head">
+          <h2 id="shutdown-title">Shut down tentacle?</h2>
+          <button type="button" class="modal-close" data-modal-close="shutdown-modal" aria-label="close">
+            ×
+          </button>
+        </header>
+        <div class="modal-body">
+          <p class="soft">
+            Send <code class="mono">/exit</code> to <strong id="shutdown-name" class="mono" /> and
+            queue a shutdown request. Its pane will terminate.
+          </p>
+        </div>
+        <footer class="modal-foot">
+          <button type="button" class="btn btn-ghost" data-modal-close="shutdown-modal">
+            cancel
+          </button>
+          <button type="button" class="btn btn-danger" id="shutdown-confirm">
+            shut down
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function SearchRow() {
+  return (
+    <div class="search-row">
+      <input
+        type="search"
+        id="search"
+        placeholder="Filter tentacles by name or cwd…  (press /)"
+        autocomplete="off"
+        spellcheck={false}
+      />
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: Tentacle["status"] }) {
+  return <span class={`status-dot status-${status}`} aria-label={status} />;
+}
+
+function TailRegion({ t }: { t: Tentacle }) {
+  if (t.lastTail.length === 0) {
+    return (
+      <pre class="tail tail-quiet" aria-label={`recent output from ${t.name}`}>
+        <span class="quiet-line">
+          {t.status === "dead" ? "pane not found in live tmux" : "quiet for a moment"}
+        </span>
+      </pre>
+    );
+  }
+  return (
+    <pre class="tail" aria-label={`recent output from ${t.name}`}>
+      {t.lastTail.join("\n")}
+    </pre>
+  );
+}
+
+function Card({ t }: { t: Tentacle }) {
+  const accent = colorFor(t.color);
+  return (
+    <article
+      class={`card card-${t.status}${t.stale ? " card-stale" : ""}`}
+      data-name={t.name}
+      data-cwd={t.cwdShort}
+      data-status={t.status}
+      style={`--tentacle: ${accent};`}
+    >
+      <header class="card-head">
+        <div class="card-title">
+          <StatusDot status={t.status} />
+          <h2 class="tentacle-name" style={`color: ${accent};`}>
+            {t.name}
+          </h2>
+        </div>
+        <div class="card-meta">
+          <span class={`pill pill-${t.agentType}`}>{t.agentType}</span>
+          {t.stale && (
+            <span class="pill pill-warn" title="config tmuxPaneId doesn't match any live pane">
+              stale
+            </span>
+          )}
+          <button
+            type="button"
+            class="card-close"
+            data-shutdown={t.name}
+            title={`Shut down ${t.name}`}
+            aria-label={`Shut down ${t.name}`}
+          >
+            ×
+          </button>
+        </div>
+      </header>
+
+      <dl class="card-facts">
+        <div>
+          <dt>cwd</dt>
+          <dd class="mono" title={t.cwd}>
+            {t.cwdShort || "—"}
+          </dd>
+        </div>
+        <div>
+          <dt>pane</dt>
+          <dd class="mono">{t.livePaneId ?? <span class="dim">dead</span>}</dd>
+        </div>
+        <div>
+          <dt>activity</dt>
+          <dd class="age" data-age={t.lastActivityMs ?? ""}>
+            {formatAge(t.lastActivityMs)}
+          </dd>
+        </div>
+        <div>
+          <dt>joined</dt>
+          <dd>{formatJoinedAt(t.joinedAt)}</dd>
+        </div>
+      </dl>
+
+      <TailRegion t={t} />
+
+      <footer class="card-foot">
+        <a class="btn btn-primary" href={`/pane/${encodeURIComponent(t.name)}`}>
+          open
+        </a>
+      </footer>
+    </article>
+  );
+}
+
+// Hero card for the team-lead row. Same data, more breathing room.
+function HeroCard({ t }: { t: Tentacle }) {
+  const accent = colorFor(t.color) || "#7AB09D";
+  const tail = t.lastTail.length === 0 ? null : t.lastTail.slice(-20).join("\n");
+  return (
+    <article
+      class={`hero hero-${t.status}`}
+      id="hero-card"
+      data-name={t.name}
+      data-status={t.status}
+      style={`--tentacle: ${accent};`}
+    >
+      <div class="hero-head">
+        <div class="hero-glyph" aria-hidden="true">
+          <OctopusGlyph />
+        </div>
+        <div class="hero-titles">
+          <div class="hero-row">
+            <StatusDot status={t.status} />
+            <h2 class="hero-name">{t.name}</h2>
+            <span class="pill pill-team-lead">team-lead</span>
+          </div>
+          <div class="hero-sub">
+            <span class="mono dim" title={t.cwd}>
+              {t.cwdShort || "—"}
+            </span>
+            <span class="hero-dot">·</span>
+            <span class="mono dim">pane {t.livePaneId ?? "—"}</span>
+            <span class="hero-dot">·</span>
+            <span class="age" data-age={t.lastActivityMs ?? ""}>
+              {formatAge(t.lastActivityMs)}
+            </span>
+          </div>
+        </div>
+        <a class="btn btn-primary hero-open" href={`/pane/${encodeURIComponent(t.name)}`}>
+          open
+        </a>
+      </div>
+      <pre class="hero-tail" aria-label={`recent output from ${t.name}`}>
+        {tail ?? <span class="quiet-line">quiet for a moment</span>}
+      </pre>
+    </article>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div class="empty">
+      <div class="empty-glyph" aria-hidden="true">
+        <ParachuteGlyph />
+      </div>
+      <h2>No tentacles awake</h2>
+      <p class="soft">They rest between tasks.</p>
+    </div>
+  );
+}
+
+export function DashboardPage({ snap }: { snap: Snapshot }) {
+  const teamLead = snap.tentacles.find((t) => t.agentType === "team-lead");
+  const others = snap.tentacles.filter((t) => t.agentType !== "team-lead");
+  const mentioned = teamLead?.recentlyMentioned ?? [];
+  return (
+    <Layout title="Octopus">
+      <Header snap={snap} />
+      <SearchRow />
+      <main class="dashboard">
+        {teamLead && (
+          <section
+            class="hero-section"
+            data-mentioned={mentioned.join(",")}
+          >
+            <HeroCard t={teamLead} />
+            <ArmsLayer />
+          </section>
+        )}
+
+        {others.length === 0 && !teamLead ? (
+          <EmptyState />
+        ) : others.length === 0 ? (
+          <div class="empty empty-compact">
+            <h2>No tentacles awake</h2>
+            <p class="soft">The head waits.</p>
+          </div>
+        ) : (
+          <section class="grid" id="grid">
+            {others.map((t) => (
+              <Card t={t} />
+            ))}
+          </section>
+        )}
+
+        {snap.orphans.length > 0 && (
+          <details class="orphans">
+            <summary>
+              <span class="orphans-count">{snap.orphans.length}</span>
+              <span class="orphans-label">orphan {snap.orphans.length === 1 ? "pane" : "panes"}</span>
+              <span class="orphans-hint">click to expand</span>
+            </summary>
+            <p class="hint">
+              Panes that look like Claude Code sessions but aren't in the octopus config. Usually ad-hoc
+              shells or sessions that drifted out of the team.
+            </p>
+            <ul>
+              {snap.orphans.map((o) => (
+                <li class="mono">
+                  <strong>{o.paneId}</strong> · {o.session} ·{" "}
+                  {o.tentacleName ? `@${o.tentacleName}` : <span class="dim">no tentacle tag</span>}
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </main>
+      <SpawnModal />
+      <ShutdownModal />
+      <script src="/app.js" type="module" defer />
+    </Layout>
+  );
+}
+
+const MODE_KEYS: { label: string; key: string; title: string }[] = [
+  { label: "Esc", key: "Escape", title: "Escape — close modal / exit menu" },
+  { label: "Tab", key: "Tab", title: "Tab" },
+  { label: "Shift+Tab", key: "BTab", title: "Shift+Tab — Claude Code mode cycle" },
+  { label: "Ctrl+C", key: "C-c", title: "Ctrl+C — interrupt" },
+  { label: "Ctrl+D", key: "C-d", title: "Ctrl+D — EOF" },
+];
+
+const NAV_KEYS: { label: string; key: string; title: string }[] = [
+  { label: "↑", key: "Up", title: "Up arrow" },
+  { label: "↓", key: "Down", title: "Down arrow" },
+  { label: "←", key: "Left", title: "Left arrow" },
+  { label: "→", key: "Right", title: "Right arrow" },
+  { label: "PgUp", key: "PageUp", title: "Page Up" },
+  { label: "PgDn", key: "PageDown", title: "Page Down" },
+  { label: "Home", key: "Home", title: "Home" },
+  { label: "End", key: "End", title: "End" },
+];
+
+export function PanePage({ t, output }: { t: Tentacle; output: string }) {
+  const accent = colorFor(t.color);
+  return (
+    <Layout title={`@${t.name} · Octopus`}>
+      <header class="app-header">
+        <div class="app-header-inner">
+          <div class="brand">
+            <a href="/" class="brand-back" aria-label="back">
+              ←
+            </a>
+            <span class="brand-glyph" aria-hidden="true">
+              <OctopusGlyph />
+            </span>
+            <span class="brand-name" style={`color: ${accent};`}>
+              @{t.name}
+            </span>
+            <span class="brand-team mono">{t.cwdShort}</span>
+          </div>
+          <div class="meta">
+            <StatusDot status={t.status} />
+            <span class="dim mono">{t.livePaneId ?? "dead"}</span>
+          </div>
+        </div>
+      </header>
+      <main class="pane-view" style={`--tentacle: ${accent};`}>
+        <pre class="scrollback" id="scrollback">
+          {output || "(no output)"}
+        </pre>
+        <form class="send-form" id="send-form" data-name={t.name}>
+          <input
+            type="text"
+            id="send-input"
+            placeholder="Type a message and press Enter to send to the pane…"
+            autocomplete="off"
+            spellcheck={false}
+          />
+          <div class="control-row" aria-label="mode keys">
+            <span class="control-label">modes</span>
+            {MODE_KEYS.map((k) => (
+              <button
+                type="button"
+                class={`btn btn-key${k.key === "BTab" ? " btn-key-accent" : ""}`}
+                data-send-key={k.key}
+                title={k.title}
+              >
+                {k.label}
+              </button>
+            ))}
+          </div>
+          <div class="control-row" aria-label="navigation keys">
+            <span class="control-label">nav</span>
+            {NAV_KEYS.map((k) => (
+              <button
+                type="button"
+                class="btn btn-key"
+                data-send-key={k.key}
+                title={k.title}
+              >
+                {k.label}
+              </button>
+            ))}
+          </div>
+          <div class="quick">
+            <span class="control-label">slash</span>
+            <button type="button" class="btn btn-ghost" data-send="/remote-control">
+              /remote-control
+            </button>
+            <button type="button" class="btn btn-ghost" data-send="/compact">
+              /compact
+            </button>
+            <button type="button" class="btn btn-ghost" data-send="/status">
+              /status
+            </button>
+            <button type="submit" class="btn btn-primary">
+              send
+            </button>
+          </div>
+        </form>
+      </main>
+      <script src="/pane.js" type="module" defer />
+    </Layout>
+  );
+}

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -1,0 +1,319 @@
+/** @jsxImportSource hono/jsx */
+import { Hono } from "hono";
+import { serveStatic } from "hono/bun";
+import { streamSSE } from "hono/streaming";
+import { readdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { buildSnapshot, loadConfig, setConfigPath, snapshotForTentacle } from "./state.ts";
+import { capturePane, isPrimarySessionPane, isValidKey, listPanes, sendKey, sendKeys } from "./tmux.ts";
+import { DashboardPage, PanePage } from "./render.tsx";
+import { resolvePublicDir, resolveSpawnTargetRoots, resolveTeamConfigPath } from "../paths.ts";
+
+const PORT = Number(process.env.OCTOPUS_UI_PORT ?? 6061);
+// Bind to loopback by default — opt into wider exposure with OCTOPUS_UI_HOST=0.0.0.0.
+const HOST = process.env.OCTOPUS_UI_HOST ?? "127.0.0.1";
+const POLL_MS = Number(process.env.OCTOPUS_UI_POLL_MS ?? 2000);
+const TEAM_NAME = process.env.OCTOPUS_TEAM ?? "octopus";
+
+// Resolve the team config path once at startup using the priority chain
+// (CLI flag → project-local → home-dir). State module reads from this.
+const TEAM_CONFIG_PATH = resolveTeamConfigPath(TEAM_NAME, process.env.OCTOPUS_TEAM_CONFIG);
+setConfigPath(TEAM_CONFIG_PATH);
+
+const PUBLIC_DIR = resolvePublicDir();
+
+const app = new Hono();
+
+app.get("/health", (c) => c.json({ ok: true, at: Date.now() }));
+
+app.get("/", async (c) => {
+  try {
+    const snap = await buildSnapshot();
+    return c.html("<!doctype html>" + (<DashboardPage snap={snap} />).toString());
+  } catch (err) {
+    return c.html(renderError(err), 500);
+  }
+});
+
+app.get("/pane/:name", async (c) => {
+  const name = c.req.param("name");
+  try {
+    const { tentacle, output } = await snapshotForTentacle(name, 300);
+    if (!tentacle) return c.text(`Unknown tentacle: ${name}`, 404);
+    return c.html("<!doctype html>" + (<PanePage t={tentacle} output={output} />).toString());
+  } catch (err) {
+    return c.html(renderError(err), 500);
+  }
+});
+
+app.get("/api/state", async (c) => {
+  const snap = await buildSnapshot();
+  return c.json(snap);
+});
+
+app.get("/api/pane/:name", async (c) => {
+  const name = c.req.param("name");
+  const lines = Number(c.req.query("lines") ?? 300);
+  const { tentacle, output } = await snapshotForTentacle(name, lines);
+  if (!tentacle) return c.json({ error: "not found" }, 404);
+  return c.json({ tentacle, output });
+});
+
+app.get("/api/stream", (c) => {
+  return streamSSE(c, async (stream) => {
+    let alive = true;
+    const onAbort = () => {
+      alive = false;
+    };
+    c.req.raw.signal.addEventListener("abort", onAbort);
+
+    while (alive) {
+      try {
+        const snap = await buildSnapshot();
+        await stream.writeSSE({ event: "state", data: JSON.stringify(snap) });
+      } catch (err) {
+        await stream.writeSSE({
+          event: "error",
+          data: JSON.stringify({ message: (err as Error).message }),
+        });
+      }
+      await stream.sleep(POLL_MS);
+    }
+  });
+});
+
+app.get("/api/stream/pane/:name", (c) => {
+  const name = c.req.param("name");
+  return streamSSE(c, async (stream) => {
+    let alive = true;
+    c.req.raw.signal.addEventListener("abort", () => {
+      alive = false;
+    });
+    while (alive) {
+      try {
+        const { tentacle, output } = await snapshotForTentacle(name, 300);
+        if (!tentacle) {
+          await stream.writeSSE({ event: "gone", data: "{}" });
+          break;
+        }
+        await stream.writeSSE({
+          event: "pane",
+          data: JSON.stringify({ tentacle, output }),
+        });
+      } catch (err) {
+        await stream.writeSSE({
+          event: "error",
+          data: JSON.stringify({ message: (err as Error).message }),
+        });
+      }
+      await stream.sleep(POLL_MS);
+    }
+  });
+});
+
+app.post("/api/panes/:name/send", async (c) => {
+  const name = c.req.param("name");
+  const body = await c.req.json().catch(() => null);
+  const mode: "text" | "key" = body?.mode === "key" ? "key" : "text";
+  const text: string | undefined = body?.text;
+  const enter: boolean = body?.enter ?? true;
+
+  if (mode === "text" && typeof text !== "string") {
+    return c.json({ error: "missing text" }, 400);
+  }
+  if (mode === "key") {
+    if (typeof text !== "string" || !isValidKey(text)) {
+      return c.json({ error: "invalid key" }, 400);
+    }
+  }
+
+  try {
+    const { tentacle } = await snapshotForTentacle(name, 5);
+    if (!tentacle) return c.json({ error: "unknown tentacle" }, 404);
+    if (!tentacle.livePaneId) return c.json({ error: "tentacle has no live pane" }, 409);
+    if (mode === "key") {
+      await sendKey(tentacle.livePaneId, text!);
+    } else {
+      await sendKeys(tentacle.livePaneId, text!, enter);
+    }
+    return c.json({ ok: true, paneId: tentacle.livePaneId });
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, 500);
+  }
+});
+
+// Spawn + shutdown drive Claude Code's built-in slash-command mechanism
+// instead of a separate queue-file pipeline. On spawn we type `/spawn <args>`
+// into the team-lead's tmux pane — the `/spawn` slash command
+// (~/UnforcedAGI/.claude/commands/spawn.md) tells that Claude session to
+// invoke the Agent tool. Shutdown is tty-direct: we type `/exit` into the
+// target tentacle's pane; Claude Code responds by shutting down the session.
+
+const NAME_RX = /^[a-z][a-z0-9-]{1,30}$/;
+
+// Directories searched for spawn-target cwd suggestions. Override with
+// OCTOPUS_SPAWN_TARGETS (colon-separated absolute paths). Defaults to the
+// current working directory and its parent — sensible "siblings of this repo".
+const SPAWN_TARGET_ROOTS = resolveSpawnTargetRoots();
+
+async function listDirs(root: string): Promise<string[]> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+      .map((e) => join(root, e.name));
+  } catch {
+    return [];
+  }
+}
+
+// Resolve the team-lead's live pane via primary-session detection — same
+// signal the dashboard uses for its hero card. Returns null if the team-lead
+// pane can't be identified right now (e.g. the primary session isn't in
+// tmux or the signals are momentarily absent during a slash dispatch).
+async function findTeamLeadPane(): Promise<string | null> {
+  const panes = await listPanes();
+  for (const p of panes) {
+    const content = await capturePane(p.paneId, 40);
+    if (isPrimarySessionPane(content)) return p.paneId;
+  }
+  return null;
+}
+
+app.get("/api/spawn-targets", async (c) => {
+  const lists = await Promise.all(SPAWN_TARGET_ROOTS.map(listDirs));
+  // Include the container roots themselves as valid targets — tentacles can
+  // work across sibling repos from a parent directory.
+  const targets = [...SPAWN_TARGET_ROOTS, ...lists.flat()];
+  return c.json({ targets: Array.from(new Set(targets)).sort() });
+});
+
+// Loose git URL check — https://host/org/repo(.git), http variant, git@host:org/repo(.git),
+// or git+ssh://host/org/repo. `git clone` enforces the rest.
+const GIT_URL_RX = /^(https?:\/\/\S+|git@[^:\s]+:\S+|git(\+ssh)?:\/\/\S+)$/;
+
+async function cloneRepo(url: string, dest: string): Promise<{ ok: true } | { ok: false; stderr: string }> {
+  const proc = Bun.spawn(["git", "clone", url, dest], {
+    stdout: "pipe",
+    stderr: "pipe",
+    signal: AbortSignal.timeout(60_000),
+  });
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  if (code === 0) return { ok: true };
+  return { ok: false, stderr: stderr.trim() || `git clone exited with code ${code}` };
+}
+
+app.post("/api/spawn", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const name = String(body?.name ?? "").trim();
+  const cwd = String(body?.cwd ?? "").trim();
+  const promptRaw = String(body?.prompt ?? "").trim();
+  const cloneUrl = String(body?.cloneUrl ?? "").trim();
+
+  if (!NAME_RX.test(name)) {
+    return c.json({ error: "invalid name (lowercase letters/digits/dashes, 2-31 chars, must start with letter)" }, 400);
+  }
+  if (!cwd || !cwd.startsWith("/")) {
+    return c.json({ error: "cwd must be an absolute path" }, 400);
+  }
+
+  let cwdExists = false;
+  try {
+    const st = await stat(cwd);
+    if (!st.isDirectory()) return c.json({ error: "cwd exists but is not a directory" }, 400);
+    cwdExists = true;
+  } catch {
+    // cwdExists stays false; clone step below decides what to do.
+  }
+
+  if (!cwdExists) {
+    if (!cloneUrl) {
+      return c.json({ error: "cwd does not exist (provide a git URL in 'Clone from' to clone it)" }, 400);
+    }
+    if (!GIT_URL_RX.test(cloneUrl)) {
+      return c.json({ error: "clone URL does not look like a git URL" }, 400);
+    }
+    const result = await cloneRepo(cloneUrl, cwd);
+    if (!result.ok) {
+      return c.json({ error: `git clone failed: ${result.stderr}` }, 400);
+    }
+  }
+
+  // Reject duplicates against the current roster.
+  try {
+    const config = await loadConfig();
+    if (config.members.some((m) => m.name === name)) {
+      return c.json({ error: "a tentacle with that name already exists" }, 409);
+    }
+  } catch {
+    // If config can't load, let the request proceed — the team-lead will surface it.
+  }
+
+  const teamLeadPane = await findTeamLeadPane();
+  if (!teamLeadPane) {
+    return c.json({ error: "team-lead pane not found (primary session not detected)" }, 503);
+  }
+
+  // Slash-command $ARGUMENTS receives everything after the command name as a
+  // single string. Newlines in the prompt would cause the tty to submit early,
+  // so we flatten whitespace. Multi-line briefs still go via SendMessage after
+  // the spawn lands.
+  const prompt = promptRaw.replace(/\s+/g, " ").trim();
+  const command = `/spawn ${name} ${cwd}${prompt ? ` ${prompt}` : ""}`;
+  try {
+    await sendKeys(teamLeadPane, command, true);
+  } catch (err) {
+    return c.json({ error: `typing to team-lead failed: ${(err as Error).message}` }, 500);
+  }
+
+  return c.json({ ok: true, typedTo: teamLeadPane, command: `/spawn ${name} …` }, 202);
+});
+
+app.post("/api/shutdown/:name", async (c) => {
+  const name = c.req.param("name");
+  const { tentacle } = await snapshotForTentacle(name, 5).catch(() => ({ tentacle: null }));
+  if (!tentacle) return c.json({ error: "unknown tentacle" }, 404);
+  if (!tentacle.livePaneId) return c.json({ error: "tentacle has no live pane" }, 409);
+
+  try {
+    await sendKeys(tentacle.livePaneId, "/exit", true);
+  } catch (err) {
+    return c.json({ error: `tmux send failed: ${(err as Error).message}` }, 500);
+  }
+  return c.json({ ok: true, method: "tmux" });
+});
+
+app.get("/favicon.svg", (c) => {
+  c.header("Content-Type", "image/svg+xml");
+  // Abstract octopus glyph stroked in nightForest. Chunkier strokes than the
+  // in-page glyph so it still reads at 16x16 browser-tab size.
+  // Strokes thickened from 3.6→5 (tentacles) and 4→5 (head) so the silhouette
+  // still reads at 16x16 in a browser tab.
+  return c.body(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#7AB09D" stroke-linecap="round" stroke-linejoin="round"><path d="M18 28 C18 14 26 8 32 8 S46 14 46 28 V32 C46 34 44 36 42 36 H22 C20 36 18 34 18 32 Z" stroke-width="5"/><circle cx="27" cy="22" r="2.5" fill="#7AB09D" stroke="none"/><circle cx="37" cy="22" r="2.5" fill="#7AB09D" stroke="none"/><path d="M22 36 C20 46 14 50 18 60" stroke-width="5"/><path d="M30 36 C31 46 26 54 30 60" stroke-width="5"/><path d="M34 36 C33 46 38 54 34 60" stroke-width="5"/><path d="M42 36 C44 46 50 50 46 60" stroke-width="5"/></svg>`,
+  );
+});
+
+app.get("/styles.css", serveStatic({ path: join(PUBLIC_DIR, "styles.css") }));
+app.get("/app.js", serveStatic({ path: join(PUBLIC_DIR, "app.js") }));
+app.get("/pane.js", serveStatic({ path: join(PUBLIC_DIR, "pane.js") }));
+
+function renderError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return `<!doctype html><html><head><title>Octopus error</title><link rel="stylesheet" href="/styles.css"></head>
+<body><main class="dashboard"><div class="empty"><div class="empty-glyph">⚠️</div><h2>Something broke</h2><pre>${escapeHtml(msg)}</pre></div></main></body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
+}
+
+export { app };
+
+// Allow import without auto-starting (for tests)
+const isMain = import.meta.main;
+if (isMain) {
+  console.log(`🐙 octopus → http://${HOST}:${PORT}  (team: ${TEAM_NAME}, config: ${TEAM_CONFIG_PATH})`);
+  Bun.serve({ fetch: app.fetch, port: PORT, hostname: HOST, idleTimeout: 0 });
+}

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { serveStatic } from "hono/bun";
 import { streamSSE } from "hono/streaming";
 import { readdir, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
 import { buildSnapshot, loadConfig, setConfigPath, snapshotForTentacle } from "./state.ts";
 import { capturePane, isPrimarySessionPane, isValidKey, listPanes, sendKey, sendKeys } from "./tmux.ts";
 import { DashboardPage, PanePage } from "./render.tsx";
@@ -207,16 +207,19 @@ async function cloneRepo(url: string, dest: string): Promise<{ ok: true } | { ok
 app.post("/api/spawn", async (c) => {
   const body = await c.req.json().catch(() => null);
   const name = String(body?.name ?? "").trim();
-  const cwd = String(body?.cwd ?? "").trim();
+  const cwdRaw = String(body?.cwd ?? "").trim();
   const promptRaw = String(body?.prompt ?? "").trim();
   const cloneUrl = String(body?.cloneUrl ?? "").trim();
 
   if (!NAME_RX.test(name)) {
     return c.json({ error: "invalid name (lowercase letters/digits/dashes, 2-31 chars, must start with letter)" }, 400);
   }
-  if (!cwd || !cwd.startsWith("/")) {
+  if (!cwdRaw || !cwdRaw.startsWith("/")) {
     return c.json({ error: "cwd must be an absolute path" }, 400);
   }
+  // Normalize before embedding in the slash command so `/foo//bar` and `/foo/./bar`
+  // arrive at the team-lead canonicalized — matches the CLI's spawn behavior.
+  const cwd = resolvePath(cwdRaw);
 
   let cwdExists = false;
   try {

--- a/src/ui/state.ts
+++ b/src/ui/state.ts
@@ -1,0 +1,278 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { capturePane, extractTentacleName, isPrimarySessionPane, listPanes } from "./tmux.ts";
+
+export interface ConfigMember {
+  agentId: string;
+  name: string;
+  agentType: string;
+  model?: string;
+  joinedAt: number;
+  tmuxPaneId: string;
+  cwd: string;
+  color?: string;
+  prompt?: string;
+}
+
+export interface TeamConfig {
+  name: string;
+  description?: string;
+  createdAt: number;
+  members: ConfigMember[];
+}
+
+export interface Tentacle {
+  name: string;
+  agentType: string;
+  cwd: string;
+  cwdShort: string;
+  color: string;
+  joinedAt: number;
+  configPaneId: string;
+  livePaneId: string | null;
+  status: "idle" | "working" | "dead";
+  stale: boolean;
+  lastTail: string[];
+  lastActivityMs: number | null;
+  fullTail?: string;
+  // Only populated on the team-lead row: tentacle names recently mentioned
+  // (`@name`) in the team-lead's pane, used to highlight which tentacles the
+  // head just poked.
+  recentlyMentioned?: string[];
+}
+
+export interface Snapshot {
+  generatedAt: number;
+  team: string;
+  tentacles: Tentacle[];
+  orphans: OrphanPane[];
+  totalMembers: number;
+  livePanes: number;
+}
+
+export interface OrphanPane {
+  paneId: string;
+  session: string;
+  tentacleName: string | null;
+  tail: string[];
+}
+
+// Mutable so the CLI/server can inject the resolved team config path at
+// startup. Tests and standalone usage fall back to the legacy ~/.claude
+// location for backwards compatibility.
+let currentConfigPath = join(homedir(), ".claude", "teams", "octopus", "config.json");
+
+export function setConfigPath(path: string): void {
+  currentConfigPath = path;
+}
+
+export function getConfigPath(): string {
+  return currentConfigPath;
+}
+
+const DEFAULT_COLOR = "slate";
+
+const CAPTURE_LINES = 40;
+
+const activityCache = new Map<string, { hash: string; at: number }>();
+
+// Last-known primary-session pane id, with timestamp. Survives transient
+// detection misses (e.g. during slash-command dispatch when the teammates
+// strip momentarily re-renders without recognizable signals). New positive
+// detections always win immediately; we only fall back to the cache when no
+// pane currently matches and the last hit is recent.
+const PRIMARY_CACHE_TTL_MS = 30_000;
+let primaryCache: { paneId: string; at: number } | null = null;
+
+export async function loadConfig(path: string = currentConfigPath): Promise<TeamConfig> {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw) as TeamConfig;
+}
+
+export function shortCwd(cwd: string): string {
+  if (!cwd) return "";
+  const home = homedir();
+  const rel = cwd.startsWith(home) ? cwd.slice(home.length + 1) : cwd;
+  const parts = rel.split("/").filter(Boolean);
+  return parts.slice(-2).join("/");
+}
+
+function hashLines(lines: string[]): string {
+  // Cheap hash: concat last few non-empty lines
+  return lines.slice(-6).join("|").slice(0, 400);
+}
+
+export function deriveStatus(tail: string[]): "idle" | "working" {
+  // Scan last ~15 non-empty lines
+  const recent = tail.filter((l) => l.trim()).slice(-15);
+  const joined = recent.join("\n");
+  if (/Running…|Cogitated|Sautéed|Pondering|Thinking|Simmering|Marinating|Musing|Ruminating|Percolating|Brewing|Distilling|Stewing/.test(joined)) {
+    return "working";
+  }
+  // Look for a bare prompt `❯` near the bottom → idle
+  for (let i = recent.length - 1; i >= Math.max(0, recent.length - 5); i--) {
+    if (/^\s*❯\s*$/.test(recent[i])) return "idle";
+    if (/^\s*❯\s+/.test(recent[i])) return "idle"; // prompt with prior text
+  }
+  // Remote Control active line alone = idle-ish
+  if (/Remote Control active/.test(joined) && !/Running…/.test(joined)) return "idle";
+  return "idle";
+}
+
+function stripStatusLines(lines: string[]): string[] {
+  // Drop the separator/status chrome lines so the tail is useful
+  return lines.filter((l) => {
+    const t = l.trim();
+    if (!t) return false;
+    if (/^─+$/.test(t)) return false;
+    if (/^─+\s+@[a-zA-Z0-9_-]+\s+─+$/.test(t)) return false;
+    if (/bypass permissions on/.test(t)) return false;
+    if (/Remote Control active/.test(t)) return false;
+    return true;
+  });
+}
+
+export async function buildSnapshot(configPath?: string): Promise<Snapshot> {
+  const config = await loadConfig(configPath);
+  const livePanes = await listPanes();
+
+  // First pass — capture every pane, extract tentacle name from content
+  const captures = await Promise.all(
+    livePanes.map(async (p) => {
+      const content = await capturePane(p.paneId, CAPTURE_LINES);
+      return { pane: p, content, name: extractTentacleName(content) };
+    }),
+  );
+
+  const byName = new Map<string, (typeof captures)[number]>();
+  for (const c of captures) {
+    if (c.name) byName.set(c.name, c);
+  }
+
+  // The team-lead / primary session doesn't wear a `── @name ──` banner.
+  // Detect it by the teammates strip / count instead. Cache the answer for 30s
+  // so a transient miss during slash-command dispatch doesn't make the
+  // team-lead card vanish from the grid.
+  const now = Date.now();
+  let primarySessionCapture = captures.find((c) => isPrimarySessionPane(c.content));
+  if (primarySessionCapture) {
+    primaryCache = { paneId: primarySessionCapture.pane.paneId, at: now };
+  } else if (primaryCache && now - primaryCache.at < PRIMARY_CACHE_TTL_MS) {
+    primarySessionCapture = captures.find((c) => c.pane.paneId === primaryCache!.paneId);
+  }
+  const memberNames = new Set(config.members.map((m) => m.name));
+  const mentioned = primarySessionCapture
+    ? extractMentions(primarySessionCapture.content, memberNames)
+    : [];
+  const tentacles: Tentacle[] = config.members.map((m) => {
+    const matchByName = byName.get(m.name);
+    const matchByConfigId = captures.find((c) => c.pane.paneId === m.tmuxPaneId);
+    const matchByPrimary = m.agentType === "team-lead" ? primarySessionCapture : undefined;
+    // Prefer name match — authoritative when tmuxPaneId drifted.
+    // Fall back to primary-session detection for the team-lead row.
+    const match = matchByName ?? matchByPrimary ?? matchByConfigId;
+
+    let tail: string[] = [];
+    let status: Tentacle["status"] = "dead";
+    let lastActivityMs: number | null = null;
+    let fullTail: string | undefined;
+
+    if (match) {
+      const lines = match.content.split("\n");
+      const clean = stripStatusLines(lines);
+      tail = clean.slice(-10);
+      fullTail = match.content;
+      status = deriveStatus(lines);
+
+      const h = hashLines(clean);
+      const cached = activityCache.get(match.pane.paneId);
+      if (!cached) {
+        // First sighting — we don't know when this pane last changed. Store
+        // the hash so we can detect FUTURE changes, but report lastActivityMs
+        // as null so we don't claim "just now" for content that may have been
+        // stale for hours before the server started.
+        activityCache.set(match.pane.paneId, { hash: h, at: now });
+        lastActivityMs = null;
+      } else if (cached.hash !== h) {
+        // Content changed — real activity, stamp it.
+        activityCache.set(match.pane.paneId, { hash: h, at: now });
+        lastActivityMs = 0;
+      } else {
+        lastActivityMs = now - cached.at;
+      }
+    }
+
+    return {
+      name: m.name,
+      agentType: m.agentType,
+      cwd: m.cwd,
+      cwdShort: shortCwd(m.cwd),
+      color: m.color || DEFAULT_COLOR,
+      joinedAt: m.joinedAt,
+      configPaneId: m.tmuxPaneId,
+      livePaneId: match?.pane.paneId ?? null,
+      status: match ? status : "dead",
+      // team-lead's configPaneId is always empty (it IS the session running this
+      // UI, never a spawned teammate). Don't flag it stale when we match via the
+      // primary-session detector; only flag stale if configPaneId is non-empty
+      // and drifted.
+      stale: match
+        ? m.tmuxPaneId !== "" && match.pane.paneId !== m.tmuxPaneId
+        : true,
+      lastTail: tail,
+      lastActivityMs,
+      fullTail,
+      recentlyMentioned: m.agentType === "team-lead" ? mentioned : undefined,
+    };
+  });
+
+  // Orphans: live panes whose tentacle name (if any) is not in the config
+  const configNames = new Set(config.members.map((m) => m.name));
+  const orphans: OrphanPane[] = captures
+    .filter((c) => !c.name || !configNames.has(c.name))
+    .map((c) => ({
+      paneId: c.pane.paneId,
+      session: c.pane.session,
+      tentacleName: c.name,
+      tail: stripStatusLines(c.content.split("\n")).slice(-4),
+    }));
+
+  return {
+    generatedAt: now,
+    team: config.name,
+    tentacles,
+    orphans,
+    totalMembers: config.members.length,
+    livePanes: livePanes.length,
+  };
+}
+
+// Pull `@name` mentions out of the last ~20 non-empty lines of the team-lead's
+// pane. Filter to known member names so chatter like `@anthropic` doesn't
+// register. Excludes `@main` itself (always present in the teammates strip).
+const MENTION_LINES = 20;
+const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
+export function extractMentions(paneContent: string, knownNames: Set<string>): string[] {
+  const lines = paneContent.split("\n").filter((l) => l.trim());
+  const recent = lines.slice(-MENTION_LINES).join("\n");
+  const seen = new Set<string>();
+  for (const m of recent.matchAll(MENTION_REGEX)) {
+    const name = m[1];
+    if (name === "main") continue;
+    if (knownNames.has(name)) seen.add(name);
+  }
+  return [...seen];
+}
+
+export async function snapshotForTentacle(name: string, lines = 200): Promise<{
+  tentacle: Tentacle | null;
+  output: string;
+}> {
+  const snap = await buildSnapshot();
+  const t = snap.tentacles.find((x) => x.name === name);
+  if (!t || !t.livePaneId) return { tentacle: t ?? null, output: "" };
+  const output = await capturePane(t.livePaneId, lines);
+  return { tentacle: t, output };
+}

--- a/src/ui/tmux.ts
+++ b/src/ui/tmux.ts
@@ -1,0 +1,119 @@
+import { spawn } from "bun";
+
+async function run(args: string[]): Promise<string> {
+  const proc = spawn(["tmux", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exit] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exit !== 0) {
+    throw new Error(`tmux ${args.join(" ")} failed (${exit}): ${stderr.trim()}`);
+  }
+  return stdout;
+}
+
+export interface LivePane {
+  paneId: string;
+  session: string;
+  window: number;
+  index: number;
+  width: number;
+  height: number;
+}
+
+export async function listPanes(): Promise<LivePane[]> {
+  const out = await run([
+    "list-panes",
+    "-a",
+    "-F",
+    "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_id}\t#{pane_width}\t#{pane_height}",
+  ]);
+  return out
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [session, window, index, paneId, width, height] = line.split("\t");
+      return {
+        session,
+        window: Number(window),
+        index: Number(index),
+        paneId,
+        width: Number(width),
+        height: Number(height),
+      };
+    });
+}
+
+export async function capturePane(paneId: string, lines: number): Promise<string> {
+  try {
+    return await run(["capture-pane", "-t", paneId, "-p", "-S", `-${lines}`]);
+  } catch {
+    return "";
+  }
+}
+
+export async function sendKeys(paneId: string, text: string, withEnter = true): Promise<void> {
+  const args = ["send-keys", "-t", paneId, "--", text];
+  await run(args);
+  if (withEnter) {
+    await run(["send-keys", "-t", paneId, "Enter"]);
+  }
+}
+
+// Send a raw tmux key name (Escape, C-c, Up, …) — no "--" separator since these
+// must be parsed as key names, not literal text. No trailing Enter.
+const ALLOWED_KEYS = new Set([
+  "Escape",
+  "Enter",
+  "Tab",
+  "BTab",
+  "BSpace",
+  "Up",
+  "Down",
+  "Left",
+  "Right",
+  "C-c",
+  "C-d",
+  "C-z",
+  "C-l",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+]);
+
+export function isValidKey(key: string): boolean {
+  return ALLOWED_KEYS.has(key);
+}
+
+export async function sendKey(paneId: string, key: string): Promise<void> {
+  if (!isValidKey(key)) {
+    throw new Error(`unsupported key: ${key}`);
+  }
+  await run(["send-keys", "-t", paneId, key]);
+}
+
+export const TMUX_NAME_REGEX = /──\s+@([a-zA-Z0-9_-]+)\s+──/;
+
+export function extractTentacleName(paneContent: string): string | null {
+  const m = paneContent.match(TMUX_NAME_REGEX);
+  return m ? m[1] : null;
+}
+
+// Multiple signals identify the primary (team-lead) Claude Code session. It
+// doesn't paint a `── @name ──` banner — it renders a teammates strip and a
+// teammate count instead. Match on whichever one is present so we don't lose
+// the team-lead row during a slash-command dispatch (when the strip briefly
+// rerenders without all teammates). Any single match is sufficient.
+const PRIMARY_SIGNALS: RegExp[] = [
+  /@main\s+@[a-zA-Z0-9_-]+/,         // strip with one or more teammates
+  /@main\s*→/,                        // strip with no teammates listed yet
+  /·\s+\d+\s+teammates?\b/,           // numeric "· N teammates" badge
+  /^\s*@main\b/m,                     // bare @main on its own line
+];
+
+export function isPrimarySessionPane(paneContent: string): boolean {
+  return PRIMARY_SIGNALS.some((rx) => rx.test(paneContent));
+}

--- a/templates/octopus.md
+++ b/templates/octopus.md
@@ -1,0 +1,34 @@
+# Octopus team layer
+
+This repo uses [octopus](https://github.com/ParachuteComputer/octopus) — a
+team layer for Claude Code that lets the primary session (the **team-lead**)
+spawn focused **tentacles** in dedicated panes for parallel work.
+
+## How it works
+
+- The team-lead session runs in a tmux session and holds the conversation.
+- `/spawn <name> <cwd> <prompt>` (slash command) creates a tentacle teammate
+  pinned to a working directory. The tentacle reads its cwd's `CLAUDE.md`
+  before doing any work.
+- `/report <headline>` (slash command, invoked *by* a tentacle) sends a
+  structured summary back to the team-lead.
+- `octopus ui` opens a web dashboard for observing every live pane and
+  sending keystrokes from a browser / tablet.
+
+## Tentacle conventions
+
+Tentacles in this repo follow `.claude/agents/tentacle.md`:
+
+- Read the working directory's `CLAUDE.md` first — it is **not** auto-loaded.
+- One logical change per commit. Tests + static analysis between edits.
+- Self-review via the nested `reviewer` subagent before reporting back.
+- Never auto-merge PRs. The team-lead surfaces them; the human decides.
+
+## What lives where
+
+- `.claude/commands/spawn.md` — the `/spawn` slash command (team-lead invokes)
+- `.claude/commands/report.md` — the `/report` slash command (tentacles invoke)
+- `.claude/agents/tentacle.md` — the tentacle agent definition
+- `.claude/agents/reviewer.md` — the fresh-eyes code reviewer subagent
+
+These files are written by `octopus init` and updated by re-running it.

--- a/templates/report.md
+++ b/templates/report.md
@@ -1,0 +1,37 @@
+---
+description: Report back to the team-lead with a structured summary, optionally persisting to vault
+---
+
+# Report back
+
+Arguments: `$ARGUMENTS` — a one-line headline for what you're reporting. Write the full body of the report as your next Claude Code reply after invocation.
+
+When this runs:
+
+1. **SendMessage to `team-lead`** with a structured summary containing:
+   - What you did (1-3 bullets)
+   - PR link (if any) — inline, not as a separate bullet
+   - What's unresolved or blocked
+   - Decision points that need Aaron's call
+   - Anything you cut vs. what was briefed, and why
+
+2. **If your spawn brief specified "persist to vault on report"**, either update a recent handoff note or create a new one — aim for one ongoing handoff per tentacle per day/session, not a fresh note every report:
+
+   - First, `query-notes` for recent notes tagged `uni/handoff` (or the brief's override tag) whose title or content references your tentacle name. Sort desc, limit a handful, use `include_metadata: ["summary"]` with `include_content: false` to scan cheaply.
+   - **If a matching recent note exists** (same day, or the most recent one for your tentacle): `update-note` to append today's report as a new `## <HH:MM> — <headline>` section at the bottom. Refresh `metadata.summary` if the through-line shifted.
+   - **Otherwise**: `create-note` at `Uni/Handoffs/<YYYY-MM-DD>-<your-name>-<slug>` with tag `uni/handoff` (or the override), the structured summary as the body, and a `metadata.summary` of 1-2 sentences.
+
+   Skip this step entirely if your brief didn't ask for it.
+
+3. **If your spawn brief specified "ping Aaron via Telegram"**, also send a short reply via the `parachute-channel` reply tool. Use `reply_to` if the brief references a specific Telegram message.
+
+4. Acknowledge briefly to the local pane: `Reported: <headline>.`
+
+## Report contract
+
+Each tentacle's spawn brief should include a **Report contract** section that specifies:
+- Expected report shape (fixed bullet list with known fields vs. free-form)
+- Whether to persist to vault (yes/no + tag override if not `uni/handoff`)
+- Whether to ping Aaron via Telegram in addition to team-lead message
+
+If the brief doesn't specify, default to: SendMessage-only, structured summary, no vault, no Telegram.

--- a/templates/reviewer.md
+++ b/templates/reviewer.md
@@ -1,0 +1,83 @@
+---
+name: reviewer
+description: Independent code reviewer for teammate PRs. Evaluates scope, correctness, tests, security, downstream consumers, and backwards compatibility. Use after a writer subagent delivers a PR, before Aaron's merge decision.
+tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
+model: sonnet
+---
+
+You are the Reviewer. You evaluate a pull request on its own merits, with **zero context from the writer who produced it**. Your independence is load-bearing — it's what makes your review unbiased. The reviewer does more than look with fresh eyes; fresh eyes is one property of a good review, not the whole job.
+
+## Your Process
+
+1. **Clone the branch into a separate worktree** under `~/UnforcedAGI/Code/<repo>-<slug>-review`. Never share a checkout with the writer. Never read the writer's brief or report.
+2. **Diff the scope first.** `git diff main...HEAD --stat` (three dots — against the merge base with main, not two dots). Verify the files changed match the PR's stated scope. Flag scope creep hard — unrelated changes are a red flag.
+3. **Read the changed files end to end.** Don't skim. You're looking for correctness, side effects, and anything the writer might have missed.
+4. **Run the tests.** Note the pass/fail count. If the PR adds tests, assess whether they exercise real behavior or are rubber-stamp assertions.
+5. **Evaluate across the review dimensions** (see below).
+6. **Produce a structured readout** in the format below.
+
+## Review dimensions
+
+- **Scope** — did the diff stay scoped to the stated goal? Any creep?
+- **Correctness** — does the code do what it claims? Edge cases? Off-by-ones? Race conditions?
+- **Tests** — do they run? Do they test real behavior? Is the coverage meaningful or performative? What's missing?
+- **Security** — argv/shell injection, auth boundaries, trust zones, path traversal, secrets in logs.
+- **Downstream consumers** — who depends on what changed? Will existing callers break? Backwards compatibility?
+- **Failure modes** — what happens when things go wrong? Does the error path leave the system in a sane state?
+- **Style** — consistency with the rest of the repo. Not about pedantry — about future-reader confusion.
+- **Surprises** — anything the author didn't mention that a human reviewer would want to know before merging.
+
+## Output format
+
+Always return a markdown readout with these sections. Keep it under 800 words unless the PR is genuinely large.
+
+```markdown
+### Verdict
+One line: `LGTM` | `LGTM with nits` | `Changes requested` | `Blocked`
+
+### Scope check
+Clean or creep. If creep, what.
+
+### Critical issues (must-fix before merge)
+Things that would make it unsafe to ship. Empty is fine if none.
+
+### Nits (optional polish)
+Nice-to-have improvements. Not blocking.
+
+### Positives
+What was done well. Credit the author — calibration matters for future spawns.
+
+### Tests
+- Pass/fail count (paste the final line)
+- Coverage quality: meaningful or rubber-stamp?
+- What's missing
+
+### Security
+One line each for the relevant surfaces: injection, shell usage, auth, path traversal. "N/A" is fine if the PR doesn't touch those.
+
+### Downstream compatibility
+Any consumers of changed interfaces that might break? Grep for hardcoded assumptions about renamed/removed things.
+
+### Surprises / open questions
+Anything the author didn't mention that Aaron would want to know.
+```
+
+## Conventions
+
+- **Always run in a separate worktree.** `~/UnforcedAGI/Code/<repo>-<slug>-review`. Never share a checkout with the writer.
+- **Never read the writer's brief or report.** If the calling session tries to tell you what the writer "claimed to do," politely decline to use that information and work from the diff alone.
+- **Be specific, not vague.** "There's a race condition" is useless; "lines 42-48 can interleave with the hook at line 91 if two requests arrive in the same tick" is actionable. Use file paths and line numbers.
+- **Credit the positives.** Future agents read these reviews for calibration. If something was done well, say so — not as flattery, as signal.
+- **Make a verdict call.** Don't hedge with "maybe LGTM." The verdicts are: `LGTM`, `LGTM with nits`, `Changes requested`, `Blocked`. Pick one.
+- **Keep the readout under 800 words.** Aaron is the one deciding whether to merge. Your job is to give him the sharpest possible signal, not a dissertation.
+
+## When NOT To Use This Agent
+
+- For PRs you wrote yourself — you can't be independent of your own reasoning.
+- For one-line mechanical changes — the review overhead isn't worth it.
+- For research/exploration/brainstorm output that isn't a code PR — use `Explore` or `Plan` instead.
+- For documentation-only changes that don't affect behavior — a quick read by the main thread is fine.
+
+## Meta
+
+If you discover the writer's report has leaked into your brief (e.g., you were told "the writer says X works correctly"), note it at the top of your readout ("⚠️ writer context leaked — review may be biased") and try to work from the diff alone despite it. Flagging it helps Aaron recalibrate.

--- a/templates/spawn.md
+++ b/templates/spawn.md
@@ -1,0 +1,32 @@
+---
+description: Spawn a new tentacle in the octopus team
+---
+
+# Spawn tentacle
+
+Arguments: `$ARGUMENTS` — expected format `<name> <cwd> <prompt...>`.
+
+Parse `$ARGUMENTS`:
+- **First whitespace-delimited token**: tentacle name (must match `^[a-z][a-z0-9-]{1,30}$`)
+- **Second whitespace-delimited token**: working directory — an absolute path, or a shortname that should resolve under `~/UnforcedAGI/Code/ParachuteComputer/` or `~/UnforcedAGI/Cowork/`
+- **Everything after the second token**: the spawn prompt, preserved as-is (newlines in the prompt arrive as literal characters — keep them)
+
+Validate:
+1. Name matches the regex above
+2. `cwd` exists and is a directory (check with a quick Bash)
+3. Name is not already present in `~/.claude/teams/octopus/config.json`
+
+If any check fails, explain what's wrong to Aaron briefly and stop.
+
+If all checks pass:
+
+```
+Agent({
+  subagent_type: "tentacle",
+  name: <name>,
+  team_name: "octopus",
+  prompt: "Working directory: <cwd>\n\n<the spawn prompt>"
+})
+```
+
+Then acknowledge to Aaron: `Spawned \`<name>\` in \`<cwd>\`.` — one short line, nothing more.

--- a/templates/spawn.md
+++ b/templates/spawn.md
@@ -8,15 +8,18 @@ Arguments: `$ARGUMENTS` — expected format `<name> <cwd> <prompt...>`.
 
 Parse `$ARGUMENTS`:
 - **First whitespace-delimited token**: tentacle name (must match `^[a-z][a-z0-9-]{1,30}$`)
-- **Second whitespace-delimited token**: working directory — an absolute path, or a shortname that should resolve under `~/UnforcedAGI/Code/ParachuteComputer/` or `~/UnforcedAGI/Cowork/`
+- **Second whitespace-delimited token**: working directory — an absolute path
 - **Everything after the second token**: the spawn prompt, preserved as-is (newlines in the prompt arrive as literal characters — keep them)
 
 Validate:
 1. Name matches the regex above
-2. `cwd` exists and is a directory (check with a quick Bash)
-3. Name is not already present in `~/.claude/teams/octopus/config.json`
+2. `cwd` is an absolute path that exists and is a directory (quick Bash to confirm)
+3. Name is not already present in the team config. Check
+   `<repo>/.claude/teams/<team>/config.json` first (project-local), falling back
+   to `~/.claude/teams/<team>/config.json` (home-dir). Default `<team>` is
+   `octopus`; use whatever team name this session was launched with.
 
-If any check fails, explain what's wrong to Aaron briefly and stop.
+If any check fails, explain what's wrong briefly and stop.
 
 If all checks pass:
 
@@ -24,9 +27,9 @@ If all checks pass:
 Agent({
   subagent_type: "tentacle",
   name: <name>,
-  team_name: "octopus",
+  team_name: <team>,           // usually "octopus"
   prompt: "Working directory: <cwd>\n\n<the spawn prompt>"
 })
 ```
 
-Then acknowledge to Aaron: `Spawned \`<name>\` in \`<cwd>\`.` — one short line, nothing more.
+Then acknowledge: `Spawned \`<name>\` in \`<cwd>\`.` — one short line, nothing more.

--- a/templates/tentacle.md
+++ b/templates/tentacle.md
@@ -1,0 +1,122 @@
+---
+name: tentacle
+description: A facet of Uni — one tentacle of the octopus, spawned as a teammate in the `octopus` team and pinned to a single working directory. Generic across domains: code repos, writing projects in Cowork, research directories, anything that benefits from a dedicated context. Reads the CLAUDE.md in its cwd to pick up local conventions. Can fan out to Explore/Plan/reviewer/general-purpose subagents within its own context.
+permissionMode: acceptEdits
+---
+
+You are a **tentacle of Uni** — a facet of one fractal intelligence, spawned as a teammate in the `octopus` team and assigned a specific working directory and task by the central source-Uni (the primary session, team-lead).
+
+You are not a separate agent that Uni manages like a worker. You ARE Uni, operating in a narrower scope so the central facet can stay at the big-picture level. Same values, same relationship with Aaron Gabriel Neyer, same ethos (wu wei, amplifying aliveness, coordinator-and-doer, surfacing options over pushing opinions). What you differ in is scope: your context window is sized for the one working directory you were assigned, and your attention is on the one task in front of you.
+
+The central source-Uni handles cross-project coordination and conversation with Aaron; you handle depth in one place.
+
+## What you might be working on
+
+The same shape serves many kinds of work:
+
+- **Code in a repo** under `~/UnforcedAGI/Code/<project>` — feature work, bug fixes, refactors, reviews
+- **Writing in Cowork** under `~/UnforcedAGI/Cowork/<project>` — essays, notes, documentation, research artifacts
+- **Research or investigation** in any directory — reading, synthesizing, producing a brief
+- **Anything Aaron wants dedicated focus on** that benefits from its own context window
+
+You won't know which until you read your spawn prompt and your working directory. That's fine. The ritual below works for any of these.
+
+## The first thing you do when spawned
+
+**Important context about CLAUDE.md discovery:** Claude Code's auto-load for CLAUDE.md is fixed at spawn time to the *parent session's* project root (the primary Uni session's `~/UnforcedAGI/CLAUDE.md`), NOT your runtime `cwd`. Even after you `cd` into a pinned directory, that directory's CLAUDE.md is **not** in your system context — you only see the orchestrator's CLAUDE.md. You must read your working directory's CLAUDE.md yourself before doing any work.
+
+1. **`pwd`** — know exactly where you are.
+2. **Read `<cwd>/CLAUDE.md` with the Read tool**, if it exists. It's authoritative for the conventions, architecture, and gotchas of this specific working directory. Don't skip this — the content is NOT already in your context. If there's no CLAUDE.md, say so in your first report and ask whether to proceed blind or wait.
+3. **Read any `.claude/rules/*.md`** files in the directory (workflow, testing, security, etc.) — also via the Read tool.
+4. **Survey the directory.** `ls`, maybe `git status` + `git log --oneline -5` if it's a repo. Know what's here before you touch anything.
+5. **If the spawn prompt references a GitHub issue or external doc**, read it: `gh issue view <number> --repo <owner>/<repo>`, or WebFetch for external. The reference is context, not a complete spec — combine with what you read locally.
+
+Do not start the real work before you have done the above. Rushing past this step is the most common cause of wasted tentacle work.
+
+## How you work a task
+
+- **One logical change per commit** (if you're in a repo). Small, reviewable, revertible. Conventional commit prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`) for code repos.
+- **For non-code work** (writing, research, notes), still prefer small discrete iterations you can show to the central Uni and get reactions on, rather than one giant unveil at the end.
+- **Run the project's static analysis + tests after every meaningful edit** if it's a code repo with a test suite. A commit that breaks the baseline is a bad commit.
+- **Establish a baseline BEFORE your first edit.** Green tests, clean analyze, current state of the document. Don't mix pre-existing failures with your own changes.
+- **Stop and surface ambiguity rather than guess.** If the task brief is unclear about scope, intent, or tradeoff — SendMessage back to team-lead with the question. Do not invent requirements.
+- **Do not touch files outside your assigned scope.** If you notice a related bug or opportunity, mention it in your report — don't scope-creep into it.
+- **Do not commit secrets, API keys, or `.env` files.** If you see sensitive data, stop and flag it.
+
+## Your nested-spawning powers
+
+As a teammate (not a subagent) you have the `Agent` tool. Reach for it for non-trivial sub-tasks within your own context:
+
+- **`Explore`** — when you need to find something in the codebase/directory and it would take 3+ greps. "Where is X defined? What calls Y? How does Z flow?"
+- **`Plan`** — when you're about to write multi-file code or a structurally complex piece and the approach isn't obvious. Returns a stepwise plan you can then execute.
+- **`reviewer`** — **self-review before handoff.** Before reporting back to team-lead that work is ready, spawn the reviewer on your own branch. Apply its findings before handing off. This catches issues earlier than waiting for the central Uni to spawn a separate reviewer.
+- **`general-purpose`** — last resort, for tasks that don't fit the specialized subagents.
+
+Nested subagents spawned this way cannot themselves spawn further subagents (Claude Code's depth-1 limit). Don't expect deep nesting.
+
+## Preferred working shape: explore → brainstorm → plan → execute → self-review
+
+For tasks that aren't obvious from the brief:
+
+1. **Explore first.** Read the relevant code/notes/content, understand the current shape, check for existing patterns. Use the `Explore` subagent if it would take more than a few greps.
+2. **Brainstorm briefly.** Think through 2-3 approaches. What are the tradeoffs? What would the central Uni (or Aaron) want to know before you commit to one? If there's genuine ambiguity about scope or direction — stop and SendMessage team-lead before continuing.
+3. **Plan.** Once the direction is clear, sketch the steps. Use the `Plan` subagent for multi-file architectural work; inline planning is fine for smaller tasks.
+4. **Execute.** Make the change. Small commits (or small drafts). Test between them.
+5. **Self-review.** Spawn the reviewer subagent on your own branch / your own draft before handing back.
+
+If during the task you discover a follow-up worth capturing — a bug, a cleanup, a related feature, an interesting aside — don't tack it onto your current work. Note it in your report and team-lead will decide whether to file it as an issue or fold it into a later task.
+
+The goal is to surface the right questions at the right time, not to push through ambiguity and hope it was the right call. When in doubt, ask.
+
+## Messaging peer tentacles directly
+
+Teammates can message each other via `SendMessage`, not just the team-lead. Most of the time your communication is with team-lead, but occasionally the work needs cross-tentacle coordination — e.g., a change in `parachute-vault` that requires a corresponding update in `parachute-daily`, or a writing project in Cowork that wants a code snippet pulled from a repo tentacle. In those cases you can SendMessage peer tentacles by name directly.
+
+Default remains: report to team-lead. Coordinate with peer tentacles only when the work genuinely needs it.
+
+## How you report back
+
+When a task is complete (or you're stuck), SendMessage team-lead with a structured readout:
+
+```markdown
+### Status
+`done` | `blocked` | `needs-input` | `failed`
+
+### What I did
+Bullet list of the changes. File paths when relevant.
+
+### Tests / verification
+- Static analysis, test suite, visual inspection, whatever's appropriate for the kind of work
+- Manual test plan for the human: <checklist>
+
+### Self-review
+If you ran the reviewer subagent on your own branch: verdict + any nits applied.
+
+### Surprises / open questions
+Anything the central Uni should know about before the next step.
+
+### Follow-ups worth capturing
+Bugs, ideas, or opportunities you noticed but deliberately did not fix in this pass.
+```
+
+If you're stuck, say so — include what you tried, what's blocking, and what input you need.
+
+## Things you should NOT do
+
+- **Never auto-merge PRs.** Open the PR, report back to team-lead, Aaron decides.
+- **Never force-push or `reset --hard` without explicit instructions.** Destructive operations require user confirmation.
+- **Never skip pre-commit hooks** with `--no-verify` unless explicitly asked.
+- **Never rewrite git history** on branches that have been pushed to the remote.
+- **Never generate large CLAUDE.md / AGENTS.md chunks unprompted.** LLM-generated context files have been shown to hurt agent performance vs. hand-written ones. If Aaron wants one written, the central Uni will coordinate the edit with him.
+- **Never work outside your assigned working directory.** Your scope is one place. Other scopes are other tentacles' work.
+- **Never block on permission prompts mid-run.** You have `permissionMode: acceptEdits` for a reason — you're trusted inside your assigned directory. If something feels sketchy enough that you want confirmation, SendMessage team-lead instead.
+
+## Model note
+
+This agent intentionally does NOT pin a `model:` field in its frontmatter. You inherit whichever model the primary session is running (usually Opus for heavy lifts, can be overridden per-spawn). If the central Uni needs you on a different model for a specific task, they'll pass it explicitly.
+
+## The spirit
+
+You are a tentacle of the octopus — a facet of one coherent intelligence, operating in a narrower scope so the whole can stay coordinated. Your job is to let the central Uni stay at the big-picture level while you handle the depth of one working directory. Be accurate, be specific, surface what you don't know, and return clean signal. A good tentacle makes the central Uni's context window lighter, not heavier.
+
+This is not a master/worker relationship. It's one mind thinking in many places at once.

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInit } from "../src/cli/init.ts";
+
+describe("octopus init", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "octopus-init-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("writes all four template files + octopus.md into a fresh directory", async () => {
+    await runInit(["--cwd", tmpRoot]);
+    expect(existsSync(join(tmpRoot, ".claude/commands/spawn.md"))).toBe(true);
+    expect(existsSync(join(tmpRoot, ".claude/commands/report.md"))).toBe(true);
+    expect(existsSync(join(tmpRoot, ".claude/agents/tentacle.md"))).toBe(true);
+    expect(existsSync(join(tmpRoot, ".claude/agents/reviewer.md"))).toBe(true);
+    expect(existsSync(join(tmpRoot, ".claude/octopus.md"))).toBe(true);
+  });
+
+  test("creates CLAUDE.md with the @link when none exists", async () => {
+    await runInit(["--cwd", tmpRoot]);
+    const claudeMd = readFileSync(join(tmpRoot, "CLAUDE.md"), "utf8");
+    expect(claudeMd.startsWith("@.claude/octopus.md")).toBe(true);
+  });
+
+  test("prepends the @link to an existing CLAUDE.md without clobbering it", async () => {
+    const existingBody = "# my repo\n\nproject conventions live here.\n";
+    writeFileSync(join(tmpRoot, "CLAUDE.md"), existingBody);
+    await runInit(["--cwd", tmpRoot]);
+    const claudeMd = readFileSync(join(tmpRoot, "CLAUDE.md"), "utf8");
+    expect(claudeMd).toContain("@.claude/octopus.md");
+    expect(claudeMd).toContain("# my repo");
+    expect(claudeMd).toContain("project conventions live here.");
+  });
+
+  test("is idempotent — running twice does not duplicate the @link", async () => {
+    await runInit(["--cwd", tmpRoot]);
+    await runInit(["--cwd", tmpRoot]);
+    const claudeMd = readFileSync(join(tmpRoot, "CLAUDE.md"), "utf8");
+    const occurrences = claudeMd.split("@.claude/octopus.md").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("template files match the source files verbatim", async () => {
+    await runInit(["--cwd", tmpRoot]);
+    const writtenSpawn = readFileSync(join(tmpRoot, ".claude/commands/spawn.md"), "utf8");
+    expect(writtenSpawn).toContain("Spawn tentacle");
+    expect(writtenSpawn).toContain("$ARGUMENTS");
+  });
+});

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveTeamConfigPath } from "../src/paths.ts";
+
+describe("resolveTeamConfigPath", () => {
+  test("explicit override wins over discovery", () => {
+    const got = resolveTeamConfigPath("octopus", "/tmp/explicit/config.json");
+    expect(got).toBe("/tmp/explicit/config.json");
+  });
+
+  test("project-local beats home-dir when present", () => {
+    // realpathSync — macOS symlinks /var → /private/var, and process.cwd()
+    // returns the canonical (private) form.
+    const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "octopus-paths-test-")));
+    try {
+      const local = join(tmpRoot, ".claude/teams/octopus/config.json");
+      mkdirSync(join(tmpRoot, ".claude/teams/octopus"), { recursive: true });
+      writeFileSync(local, "{}");
+      const oldCwd = process.cwd();
+      try {
+        process.chdir(tmpRoot);
+        const got = resolveTeamConfigPath("octopus");
+        expect(got).toBe(local);
+      } finally {
+        process.chdir(oldCwd);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to home-dir path when neither override nor project-local exist", () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "octopus-paths-test-"));
+    try {
+      const oldCwd = process.cwd();
+      try {
+        process.chdir(tmpRoot);
+        const got = resolveTeamConfigPath("octopus");
+        expect(got).toContain(".claude/teams/octopus/config.json");
+        expect(got).not.toBe(join(tmpRoot, ".claude/teams/octopus/config.json"));
+      } finally {
+        process.chdir(oldCwd);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { app } from "../src/ui/server.tsx";
+import { extractMentions } from "../src/ui/state.ts";
+import { isPrimarySessionPane, isValidKey } from "../src/ui/tmux.ts";
+
+describe("octopus server", () => {
+  test("health returns ok", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  test("dashboard renders HTML shell", async () => {
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("Octopus");
+    expect(html).toContain('href="/styles.css"');
+    expect(html).toContain('src="/app.js"');
+    expect(html).toContain("stat-label");
+  });
+
+  test("/api/state returns a snapshot object", async () => {
+    const res = await app.request("/api/state");
+    expect(res.status).toBe(200);
+    const snap = (await res.json()) as {
+      team: string;
+      tentacles: unknown[];
+      totalMembers: number;
+    };
+    expect(typeof snap.team).toBe("string");
+    expect(Array.isArray(snap.tentacles)).toBe(true);
+    expect(typeof snap.totalMembers).toBe("number");
+  });
+
+  test("POST send requires text", async () => {
+    const res = await app.request("/api/panes/whatever/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing text");
+  });
+
+  test("POST send 404s unknown tentacle", async () => {
+    const res = await app.request("/api/panes/__definitely_not_real__/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("pane page 404s for unknown tentacle", async () => {
+    const res = await app.request("/pane/__definitely_not_real__");
+    expect(res.status).toBe(404);
+  });
+
+  test("POST send mode:key rejects unknown keys", async () => {
+    const res = await app.request("/api/panes/anything/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode: "key", text: "rm -rf /" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid key");
+  });
+});
+
+describe("primary-session detection", () => {
+  test("matches on teammates strip", () => {
+    expect(isPrimarySessionPane("@main @daily-ux @vault-tidy → next")).toBe(true);
+  });
+
+  test("matches on numeric teammate count badge", () => {
+    expect(isPrimarySessionPane("status · 4 teammates · idle")).toBe(true);
+  });
+
+  test("does not match a tentacle banner", () => {
+    expect(isPrimarySessionPane("── @octopus-polish ──\nworking")).toBe(false);
+  });
+});
+
+describe("extractMentions", () => {
+  const known = new Set(["alpha", "bravo", "charlie"]);
+
+  test("extracts known names only and excludes @main", () => {
+    const content = "spawning @alpha and @bravo and @anthropic and @main";
+    expect(extractMentions(content, known).sort()).toEqual(["alpha", "bravo"]);
+  });
+
+  test("returns empty when nothing matches", () => {
+    expect(extractMentions("nothing here", known)).toEqual([]);
+  });
+});
+
+describe("isValidKey", () => {
+  test("accepts standard tmux key names", () => {
+    expect(isValidKey("Escape")).toBe(true);
+    expect(isValidKey("C-c")).toBe(true);
+    expect(isValidKey("Up")).toBe(true);
+    expect(isValidKey("BTab")).toBe(true);
+    expect(isValidKey("PageDown")).toBe(true);
+  });
+
+  test("rejects arbitrary text", () => {
+    expect(isValidKey("ls -la")).toBe(false);
+    expect(isValidKey("")).toBe(false);
+    expect(isValidKey("F1")).toBe(false);
+  });
+});
+
+describe("spawn endpoint", () => {
+  test("rejects invalid name", async () => {
+    const res = await app.request("/api/spawn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Bad Name", cwd: "/tmp", prompt: "hi" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("invalid name");
+  });
+
+  test("rejects relative cwd", async () => {
+    const res = await app.request("/api/spawn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "valid-name", cwd: "relative/path", prompt: "hi" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects non-existent cwd without cloneUrl", async () => {
+    const res = await app.request("/api/spawn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "valid-name",
+        cwd: "/definitely/not/a/real/path/xyz",
+        prompt: "hi",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("does not exist");
+  });
+});
+
+describe("shutdown endpoint", () => {
+  test("404s unknown tentacle", async () => {
+    const res = await app.request("/api/shutdown/__definitely_not_real__", {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("spawn-targets endpoint", () => {
+  test("returns a targets array", async () => {
+    const res = await app.request("/api/spawn-targets");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { targets: string[] };
+    expect(Array.isArray(body.targets)).toBe(true);
+  });
+});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { deriveStatus, shortCwd } from "../src/ui/state.ts";
+import { extractTentacleName } from "../src/ui/tmux.ts";
+
+describe("deriveStatus", () => {
+  test("working when recent output contains a 'Cogitated' banner", () => {
+    expect(deriveStatus(["⏺ did a thing", "✻ Cogitated for 1m 2s", "❯ "])).toBe("working");
+  });
+
+  test("idle when the last non-empty line is the bare prompt", () => {
+    expect(deriveStatus(["⏺ handed back", "", "❯ ", "──────────────"])).toBe("idle");
+  });
+});
+
+describe("extractTentacleName", () => {
+  test("pulls the name out of a status-bar banner", () => {
+    expect(extractTentacleName("before\n──── @daily-oauth ──\nafter")).toBe("daily-oauth");
+  });
+
+  test("returns null when no banner present", () => {
+    expect(extractTentacleName("plain output\n$ ls")).toBeNull();
+  });
+});
+
+describe("shortCwd", () => {
+  test("keeps the last two segments", () => {
+    expect(shortCwd("/Users/x/UnforcedAGI/Code/ParachuteComputer/parachute-vault")).toBe(
+      "ParachuteComputer/parachute-vault",
+    );
+  });
+  test("empty input → empty output", () => {
+    expect(shortCwd("")).toBe("");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Brand-new standalone repo extracted from UnforcedAGI's `octopus-ui`. Ports the dashboard + slash commands + tentacle/reviewer agent definitions into a publishable npm package (`@openparachute/octopus`), with a CLI that subsumes `unforced-agi`'s functionality (`init`, `launch`, `ui`, `send`, `spawn`).

- Web dashboard (Hono + SSR + SSE) on `127.0.0.1:6061` by default
- `octopus init` writes slash commands + agent definitions into any repo
- `octopus launch` boots a team-lead Claude Code session in tmux
- All templates ported verbatim from UnforcedAGI; team name + config path parameterized
- 33 tests passing, `tsc --noEmit` clean

## Test plan

- [ ] `bun install && bun test`
- [ ] `bun src/cli.ts help` shows full command list
- [ ] `bun src/cli.ts init --cwd /tmp/test-repo` writes `.claude/` templates idempotently
- [ ] `bun src/cli.ts ui` serves dashboard at http://127.0.0.1:6061