### PR TITLE
feat(ui): unified launch+ui lifecycle (tmux-owned), default 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ From the root of any repo:
 
 ```bash
 octopus init        # writes .claude/commands + agents + octopus.md
-octopus launch      # starts tmux + Claude Code as the team-lead
-octopus ui          # opens the web dashboard at http://127.0.0.1:6061
+octopus launch      # starts tmux + Claude Code as the team-lead AND the UI
+                    # (one tmux session owns both — no orphan processes)
 ```
 
-The team-lead is now ready. Type `/spawn <name> <cwd> <prompt>` in its pane
-to spin up a tentacle, or use the **🐙 spawn** button in the dashboard.
+The team-lead is now ready. The UI is at `http://127.0.0.1:6061` (or your
+Tailscale address — see *UI lifecycle* below). Type `/spawn <name> <cwd>
+<prompt>` in the team-lead pane, or use the **🐙 spawn** button in the
+dashboard.
+
+> Need just the UI? `octopus ui` runs it standalone (daemonized).
+> Need to stop it? `octopus ui stop`. See *UI lifecycle* below.
 
 ## How it works
 
@@ -81,20 +86,55 @@ Bootstrap the current repo. Writes:
 Idempotent: re-running overwrites the four template files but preserves the
 rest of `CLAUDE.md`. Default team name is `octopus`.
 
-### `octopus launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>]`
+### `octopus launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>] [--no-ui] [--ui-port <n>] [--ui-host <addr>]`
 
-Start (or attach to) a tmux session running Claude Code as the team-lead.
+Start (or attach to) a tmux session running Claude Code as the team-lead, and
+**spawn the web UI as a managed window in the same tmux session**. One tmux
+session owns both — kill the session, both die. No orphan processes.
+
 Defaults: team `octopus`, cwd `$PWD`, session name = team name. Inside an
-existing tmux session it does `switch-client` instead of `attach`.
+existing tmux session it does `switch-client` instead of `attach`. Pass
+`--no-ui` to skip the UI window (useful in dev when you want to run the UI
+yourself with `bun --hot`).
 
-### `octopus ui [--team <name>] [--port 6061] [--host 127.0.0.1] [--team-config <path>]`
+### `octopus ui [--team <name>] [--port 6061] [--host 0.0.0.0] [--team-config <path>] [--foreground]`
 
-Start the web dashboard. Loopback only by default. Opt into LAN/Tailscale
-exposure with `--host 0.0.0.0`. The team config path is resolved from:
+Standalone UI process. **Daemonizes by default** — the server keeps running
+after your shell closes; logs go to `~/.local/state/octopus/ui.log`.
+
+Idempotent: if a UI is already running (whether spawned by `octopus launch`,
+a previous `octopus ui`, or anywhere else), prints the URL and exits 0
+instead of crashing on `EADDRINUSE`.
+
+Pass `--foreground` to run attached to your terminal (used by `octopus
+launch`'s tmux window, and handy for dev — `bun --hot src/cli.ts ui --foreground`).
+
+The default host is **`0.0.0.0`** (changed in 0.2.0). The dashboard shells
+`tmux send-keys` into every pane on the box — auth lives at the **network**
+layer, not the app layer. Bind only to interfaces gated by Tailscale or a
+firewall. Use `--host 127.0.0.1` to restrict to loopback.
+
+The team config path is resolved from:
 
 1. `--team-config` flag (or `OCTOPUS_TEAM_CONFIG` env)
 2. `<cwd>/.claude/teams/<team>/config.json` (project-local)
 3. `~/.claude/teams/<team>/config.json` (home-dir, Claude Code default)
+
+### `octopus ui stop [--timeout 3000]`
+
+SIGTERM the running UI (looked up via PID file), wait for clean exit, remove
+the PID file. Refuses to kill the recorded PID if it now belongs to a
+non-octopus process. Cleans up stale PID files automatically.
+
+### `octopus ui restart [<ui flags>]`
+
+Stop, then start with the given flags.
+
+### `octopus ui status`
+
+Print PID, URL, mode (`tmux` / `daemon` / `foreground`), and the PID-file
+path. Useful when you want to know whether *anything* is running before
+launching another UI.
 
 ### `octopus send <text...> [--session <name>]`
 
@@ -135,12 +175,30 @@ gives a readable dashboard with no JS.
 | `POST` | `/api/shutdown/:name`   | Send `/exit` to a tentacle |
 | `GET`  | `/api/spawn-targets`    | Datalist suggestions for the spawn modal |
 
+## UI lifecycle
+
+There are three ways the UI can be running, and they're distinguishable via
+`octopus ui status`:
+
+| Mode | How it got there | Stopped by |
+| --- | --- | --- |
+| `tmux` | Spawned by `octopus launch` as a window in its tmux session | Killing the tmux session (or the window) |
+| `daemon` | `octopus ui` standalone (default) | `octopus ui stop` |
+| `foreground` | `octopus ui --foreground` (dev mode, or the body of the tmux window) | Ctrl-C in its terminal |
+
+Only one UI runs at a time on a given port. The PID file at
+`${XDG_STATE_HOME:-~/.local/state}/octopus/ui.pid` is the source of truth;
+combined with a `/api/health` self-identification endpoint it lets the CLI
+distinguish "another octopus UI" from "a foreign process holding the port"
+and react accordingly (no-op vs. error).
+
 ## Auth
 
 **None at the app layer.** This server shells `tmux send-keys` into every
 pane on the box — it is *intentionally* gated at the network layer, not the
-app layer. Bind it to localhost or a Tailscale-only interface and rely on
-network ACLs. Do not expose it on the open internet.
+app layer. The default bind host is `0.0.0.0`, which assumes you're on a
+Tailscale-only or firewalled interface. If you're not, pass `--host
+127.0.0.1`. Do not expose it on the open internet.
 
 ## Where octopus sits in the Parachute family
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/octopus",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Team layer for Claude Code — spawn, observe, and coordinate tentacles (Claude Code teammates) in any repo.",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,8 +15,12 @@ const VERSION = "0.2.0";
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
 
-  if (!command || command === "help" || command === "--help" || command === "-h") {
+  if (!command || command === "--help" || command === "-h") {
     runHelp();
+    return;
+  }
+  if (command === "help") {
+    runHelp(rest[0]);
     return;
   }
   if (command === "version" || command === "--version" || command === "-v") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { runSend } from "./cli/send.ts";
 import { runSpawn } from "./cli/spawn.ts";
 import { runUi } from "./cli/ui.ts";
 
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -11,15 +11,30 @@ Commands:
       the tentacle/reviewer agent definitions into .claude/, and ensures
       CLAUDE.md links the octopus conventions snippet.
 
-  launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>] [--no-skip-permissions]
+  launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>]
+         [--no-skip-permissions] [--no-ui] [--ui-port <n>] [--ui-host <addr>]
       Start (or attach to) a tmux session running Claude Code as the team-lead.
+      By default ALSO spawns the web UI as a managed window in the same tmux
+      session — one lifecycle, no orphan processes. Pass --no-ui to skip.
       Defaults: team "octopus", cwd "$PWD", session = team name. Passes
       --dangerously-skip-permissions to claude by default; opt out with
       --no-skip-permissions or OCTOPUS_SKIP_PERMISSIONS=false.
 
-  ui [--team <name>] [--port 6061] [--host 127.0.0.1]
-      Start the web dashboard. Loopback by default; pass --host 0.0.0.0 to
-      expose it on the LAN / Tailscale.
+  ui [--team <name>] [--port 6061] [--host 0.0.0.0] [--foreground]
+      Start the web dashboard. Daemonizes by default (logs to
+      ~/.local/state/octopus/ui.log). Idempotent — if already running, prints
+      the URL and exits 0. Pass --foreground to run attached to the terminal.
+      Default host is 0.0.0.0 (gate at the network layer — Tailscale, firewall).
+
+  ui stop [--timeout <ms>]
+      SIGTERM the running UI, wait for clean exit, remove PID file. Refuses
+      to kill if the recorded PID belongs to a non-octopus process.
+
+  ui restart [<ui flags>]
+      Stop, then start with the given flags.
+
+  ui status
+      Print PID, URL, mode (tmux / daemon / foreground), and PID-file path.
 
   send <text...> [--session <name>]
       Send keystrokes to the team-lead's tmux session via tmux send-keys.
@@ -35,9 +50,10 @@ Environment:
   OCTOPUS_TEAM            Override default team name ("octopus")
   OCTOPUS_TEAM_CONFIG     Absolute path to a team config.json (skips lookup)
   OCTOPUS_UI_PORT         UI port (default 6061)
-  OCTOPUS_UI_HOST         UI bind host (default 127.0.0.1)
+  OCTOPUS_UI_HOST         UI bind host (default 0.0.0.0)
   OCTOPUS_UI_POLL_MS      Snapshot interval in ms (default 2000)
   OCTOPUS_SPAWN_TARGETS   Colon-separated absolute paths for spawn datalist
+  XDG_STATE_HOME          PID file + log dir (defaults to ~/.local/state)
 
 Learn more: https://github.com/ParachuteComputer/octopus
 `);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,60 +1,63 @@
-export function runHelp(): void {
+export function runHelp(command?: string): void {
+  if (command === "launch") return helpLaunch();
+  if (command === "ui") return helpUi();
+  if (command === "env") return helpEnv();
   console.log(`octopus — team layer for Claude Code
 
-A spawn / observe / coordinate harness for Claude Code teammates ("tentacles")
-in any repo. One central session (the team-lead) holds the conversation;
-tentacles do the focused work in their own panes.
+commands:
+  launch          start tmux session with team-lead + web dashboard
+  ui              start / stop / restart the web dashboard
+  send <text>     send keystrokes to the team-lead pane
 
-Commands:
-  init [--team <name>]
-      Bootstrap the current repo: writes the spawn/report slash commands and
-      the tentacle/reviewer agent definitions into .claude/, and ensures
-      CLAUDE.md links the octopus conventions snippet.
+  init            bootstrap octopus in the current repo
+  spawn <n> <d>   type /spawn into the team-lead pane
+  help <command>  detailed help (launch, ui, env)
 
-  launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>]
-         [--no-skip-permissions] [--no-ui] [--ui-port <n>] [--ui-host <addr>]
-      Start (or attach to) a tmux session running Claude Code as the team-lead.
-      By default ALSO spawns the web UI as a managed window in the same tmux
-      session — one lifecycle, no orphan processes. Pass --no-ui to skip.
-      Defaults: team "octopus", cwd "$PWD", session = team name. Passes
-      --dangerously-skip-permissions to claude by default; opt out with
-      --no-skip-permissions or OCTOPUS_SKIP_PERMISSIONS=false.
+https://github.com/ParachuteComputer/octopus
+`);
+}
 
-  ui [--team <name>] [--port 6061] [--host 0.0.0.0] [--foreground]
-      Start the web dashboard. Daemonizes by default (logs to
-      ~/.local/state/octopus/ui.log). Idempotent — if already running, prints
-      the URL and exits 0. Pass --foreground to run attached to the terminal.
-      Default host is 0.0.0.0 (gate at the network layer — Tailscale, firewall).
+function helpLaunch(): void {
+  console.log(`octopus launch — start tmux + claude code as team-lead
 
-  ui stop [--timeout <ms>]
-      SIGTERM the running UI, wait for clean exit, remove PID file. Refuses
-      to kill if the recorded PID belongs to a non-octopus process.
+  --team <name>           team name (default: octopus)
+  --cwd <path>            working directory (default: $PWD)
+  --session <name>        tmux session name (default: team name)
+  --model <id>            claude model override
+  --no-skip-permissions   don't pass --dangerously-skip-permissions
+  --no-ui                 skip starting the web dashboard
+  --ui-port <n>           dashboard port (default: 6061)
+  --ui-host <addr>        dashboard bind address (default: 0.0.0.0)
+`);
+}
 
-  ui restart [<ui flags>]
-      Stop, then start with the given flags.
+function helpUi(): void {
+  console.log(`octopus ui — web dashboard lifecycle
 
-  ui status
-      Print PID, URL, mode (tmux / daemon / foreground), and PID-file path.
+  octopus ui              start (daemonizes by default)
+  octopus ui stop         stop the running dashboard
+  octopus ui restart      stop + start with new flags
+  octopus ui status       show pid, url, mode
 
-  send <text...> [--session <name>]
-      Send keystrokes to the team-lead's tmux session via tmux send-keys.
+flags:
+  --host <addr>           bind address (default: 0.0.0.0)
+  --port <n>              port (default: 6061)
+  --team <name>           team name (default: octopus)
+  --team-config <path>    explicit config.json path
+  --foreground            run attached to terminal (don't daemonize)
+  --poll-ms <n>           snapshot interval in ms (default: 2000)
+`);
+}
 
-  spawn <name> <cwd> <prompt...> [--session <name>]
-      Type \`/spawn <name> <cwd> <prompt>\` into the team-lead's pane.
-      Convenience for firing the slash command from a terminal.
+function helpEnv(): void {
+  console.log(`octopus — environment variables
 
-  help, --help, -h     Show this help
-  version, --version   Show version
-
-Environment:
-  OCTOPUS_TEAM            Override default team name ("octopus")
-  OCTOPUS_TEAM_CONFIG     Absolute path to a team config.json (skips lookup)
-  OCTOPUS_UI_PORT         UI port (default 6061)
-  OCTOPUS_UI_HOST         UI bind host (default 0.0.0.0)
-  OCTOPUS_UI_POLL_MS      Snapshot interval in ms (default 2000)
-  OCTOPUS_SPAWN_TARGETS   Colon-separated absolute paths for spawn datalist
-  XDG_STATE_HOME          PID file + log dir (defaults to ~/.local/state)
-
-Learn more: https://github.com/ParachuteComputer/octopus
+  OCTOPUS_TEAM            default team name (default: octopus)
+  OCTOPUS_TEAM_CONFIG     absolute path to config.json (skips lookup)
+  OCTOPUS_UI_PORT         dashboard port (default: 6061)
+  OCTOPUS_UI_HOST         dashboard bind address (default: 0.0.0.0)
+  OCTOPUS_UI_POLL_MS      snapshot interval in ms (default: 2000)
+  OCTOPUS_SPAWN_TARGETS   colon-separated paths for spawn cwd suggestions
+  XDG_STATE_HOME          pid file + log dir (default: ~/.local/state)
 `);
 }

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -165,6 +165,7 @@ async function ensureUiWindow(opts: EnsureUiOpts): Promise<void> {
 function quote(s: string): string {
   // Shell-quote for the tmux command string. tmux runs the command via
   // /bin/sh -c, so single-quote anything containing whitespace or shell metas.
-  if (/^[a-zA-Z0-9_./@:=+-]+$/.test(s)) return s;
+  // Note: `-` placed at end of class to avoid being misread as a range.
+  if (/^[a-zA-Z0-9_./@:=+-]+$/.test(s)) return s; // eslint-disable-line no-useless-escape
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -1,10 +1,31 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseFlags } from "./flags.ts";
-import { tmuxHasSession, which } from "./tmux.ts";
+import {
+  tmuxHasSession,
+  tmuxListWindows,
+  tmuxNewWindow,
+  which,
+} from "./tmux.ts";
+import {
+  isProcessAlive,
+  probeOctopusUi,
+  readPidFile,
+} from "../ui/pidfile.ts";
+
+const UI_WINDOW_NAME = "octopus-ui";
 
 export async function runLaunch(argv: string[]): Promise<void> {
-  const { flags } = parseFlags(argv, ["team", "cwd", "session", "model", "no-skip-permissions"]);
+  const { flags } = parseFlags(argv, [
+    "team",
+    "cwd",
+    "session",
+    "model",
+    "no-skip-permissions",
+    "no-ui",
+    "ui-port",
+    "ui-host",
+  ]);
   const team = (flags.team as string) ?? process.env.OCTOPUS_TEAM ?? "octopus";
   const cwd = resolve((flags.cwd as string) ?? process.cwd());
   const session = (flags.session as string) ?? team;
@@ -55,6 +76,19 @@ export async function runLaunch(argv: string[]): Promise<void> {
     console.log(`started octopus team "${team}" in tmux session "${session}" (cwd: ${cwd})`);
   }
 
+  // Bring up the UI as a managed window inside the same tmux session, unless
+  // disabled. tmux owns the lifecycle: kill the session → window dies → bun
+  // dies → PID file cleared by the ui process's SIGTERM handler.
+  if (!flags["no-ui"]) {
+    await ensureUiWindow({
+      session,
+      cwd,
+      port: flags["ui-port"] ? Number(flags["ui-port"]) : undefined,
+      host: flags["ui-host"] ? String(flags["ui-host"]) : undefined,
+      team,
+    });
+  }
+
   const insideTmux = !!process.env.TMUX;
   const attachCmd = insideTmux
     ? ["tmux", "switch-client", "-t", session]
@@ -66,4 +100,71 @@ export async function runLaunch(argv: string[]): Promise<void> {
   });
   const code = await attach.exited;
   process.exit(code);
+}
+
+interface EnsureUiOpts {
+  session: string;
+  cwd: string;
+  port?: number;
+  host?: string;
+  team: string;
+}
+
+async function ensureUiWindow(opts: EnsureUiOpts): Promise<void> {
+  // 1. If a UI is already running (anywhere — tmux, daemon, foreign), don't
+  //    spawn a second one. Point at the live one and move on.
+  const existing = readPidFile();
+  if (existing && isProcessAlive(existing.pid)) {
+    const probe = await probeOctopusUi(existing.host, existing.port);
+    if (probe) {
+      console.log(
+        `   UI already running (pid ${existing.pid}, mode ${existing.mode}) → http://${existing.host === "0.0.0.0" ? "127.0.0.1" : existing.host}:${existing.port}`,
+      );
+      return;
+    }
+  }
+
+  // 2. If our session already has the UI window, leave it alone (idempotent
+  //    re-launch).
+  if (tmuxListWindows(opts.session).includes(UI_WINDOW_NAME)) {
+    console.log(`   UI window "${UI_WINDOW_NAME}" already present in session "${opts.session}".`);
+    return;
+  }
+
+  // 3. Build the command. Prefer the `octopus` bin if it's on PATH so the
+  //    window survives a `bun upgrade` of the dev tree; fall back to invoking
+  //    this same script via bun for source-tree development.
+  const flags = [
+    "--foreground",
+    "--tmux-session",
+    opts.session,
+    "--team",
+    opts.team,
+  ];
+  if (opts.port !== undefined) flags.push("--port", String(opts.port));
+  if (opts.host !== undefined) flags.push("--host", opts.host);
+  const uiCmd = which("octopus")
+    ? ["octopus", "ui", ...flags].map(quote).join(" ")
+    : [process.execPath, process.argv[1], "ui", ...flags].map(quote).join(" ");
+
+  const code = tmuxNewWindow(opts.session, UI_WINDOW_NAME, opts.cwd, uiCmd);
+  if (code !== 0) {
+    console.error(
+      `warning: failed to start UI window (tmux exited ${code}). You can start it manually with \`octopus ui\`.`,
+    );
+    return;
+  }
+  const port = opts.port ?? Number(process.env.OCTOPUS_UI_PORT ?? 6061);
+  const host = opts.host ?? process.env.OCTOPUS_UI_HOST ?? "0.0.0.0";
+  const display = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  console.log(
+    `   UI window "${UI_WINDOW_NAME}" started in session "${opts.session}" → http://${display}:${port}`,
+  );
+}
+
+function quote(s: string): string {
+  // Shell-quote for the tmux command string. tmux runs the command via
+  // /bin/sh -c, so single-quote anything containing whitespace or shell metas.
+  if (/^[a-zA-Z0-9_./@:=+-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
 }

--- a/src/cli/tmux.ts
+++ b/src/cli/tmux.ts
@@ -15,6 +15,52 @@ export function tmuxHasSession(name: string): boolean {
   return r.exitCode === 0;
 }
 
+/**
+ * Returns the list of window names in a session, or [] if the session
+ * doesn't exist or tmux fails. Used to make `octopus launch`'s UI-window
+ * setup idempotent.
+ */
+export function tmuxListWindows(session: string): string[] {
+  const r = Bun.spawnSync(
+    ["tmux", "list-windows", "-t", session, "-F", "#{window_name}"],
+    { stdout: "pipe", stderr: "ignore" },
+  );
+  if (r.exitCode !== 0) return [];
+  const out = new TextDecoder().decode(r.stdout);
+  return out
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Creates a new detached window in the given session running `command`.
+ * Returns the exit code of `tmux new-window`.
+ */
+export function tmuxNewWindow(
+  session: string,
+  windowName: string,
+  cwd: string,
+  command: string,
+): number {
+  const r = Bun.spawnSync(
+    [
+      "tmux",
+      "new-window",
+      "-d",
+      "-t",
+      session,
+      "-n",
+      windowName,
+      "-c",
+      cwd,
+      command,
+    ],
+    { stdout: "inherit", stderr: "inherit" },
+  );
+  return r.exitCode ?? 1;
+}
+
 export function tmuxSendKeys(target: string, text: string, withEnter = true): number {
   const args = ["tmux", "send-keys", "-t", target, "--", text];
   const r = Bun.spawnSync(args, { stdout: "inherit", stderr: "inherit" });

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, openSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { parseFlags } from "./flags.ts";
@@ -98,6 +98,16 @@ async function alreadyRunning(opts: UiOptions): Promise<UiPidRecord | null> {
   if (existing && isProcessAlive(existing.pid)) {
     const probe = await probeOctopusUi(existing.host, existing.port);
     if (probe) return existing;
+    // Process alive but not responding — could be mid-startup, mid-shutdown,
+    // or genuinely orphaned (e.g. crashed listener, recycled PID). Surface
+    // the ambiguity so the user can decide rather than silently spawning a
+    // second daemon.
+    console.error(
+      `warning: PID ${existing.pid} is alive but not responding on ${existing.host}:${existing.port}.`,
+    );
+    console.error(
+      `         the PID file may be stale (different process now); run \`octopus ui stop\` to clear it.`,
+    );
   } else if (existing) {
     removePidFile(); // stale
   }
@@ -155,7 +165,7 @@ async function runUiStart(argv: string[]): Promise<void> {
 
   // 4. Default: daemonize. Spawn ourselves with --foreground and exit so the
   //    user's shell isn't holding the server. Logs go to the state dir.
-  return spawnDaemon(opts);
+  await spawnDaemon(opts);
 }
 
 async function runForeground(opts: UiOptions): Promise<void> {
@@ -217,7 +227,7 @@ async function runForeground(opts: UiOptions): Promise<void> {
   }
 }
 
-function spawnDaemon(opts: UiOptions): void {
+async function spawnDaemon(opts: UiOptions): Promise<void> {
   const log = logFilePath();
   mkdirSync(dirname(log), { recursive: true });
   const fd = openSync(log, "a");
@@ -234,6 +244,18 @@ function spawnDaemon(opts: UiOptions): void {
     env: { ...process.env, OCTOPUS_UI_DAEMONIZED: "1" },
   });
   child.unref();
+  // Parent has handed the fd to the child; close our reference so we don't
+  // hold an extra one until process exit.
+  closeSync(fd);
+
+  // Wait briefly for the child to write its PID file so the user gets a
+  // crisp "started" report rather than racing `octopus ui status`.
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    const rec = readPidFile();
+    if (rec && rec.pid === child.pid) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
 
   console.log(`🐙 octopus UI starting in background → ${displayUrl(opts.host, opts.port)}`);
   console.log(`   logs: ${log}`);
@@ -268,7 +290,11 @@ async function runUiStop(argv: string[]): Promise<void> {
     return;
   }
 
-  // PID alive — verify it self-identifies as us before signaling.
+  // PID alive — verify it self-identifies as us before signaling. We treat
+  // any failure of the health probe as "do not signal" because PID numbers
+  // can be reused by the OS if our previous process crashed without removing
+  // the PID file (SIGKILL, OOM, etc.). Trusting the PID file alone risks
+  // killing a foreign process that happened to inherit the number.
   const probe = await probeOctopusUi(record.host, record.port);
   if (!probe || probe.pid !== record.pid) {
     if (await isPortHeld(record.host, record.port)) {
@@ -279,14 +305,22 @@ async function runUiStop(argv: string[]): Promise<void> {
       process.exit(1);
     }
     console.log(
-      `PID ${record.pid} is alive but no octopus UI is responding on ${record.host}:${record.port}.`,
+      `stale-looking PID file: pid ${record.pid} is alive but not responding as an octopus UI on ${record.host}:${record.port}.`,
     );
-    console.log(`Sending SIGTERM anyway (recorded as octopus UI in PID file).`);
+    console.log(
+      `Removing PID file but NOT signaling pid ${record.pid} (could be a recycled PID belonging to a foreign process).`,
+    );
+    console.log(`If you're sure pid ${record.pid} is the leaked octopus UI, kill it manually.`);
+    removePidFile();
+    return;
   }
 
   if (record.mode === "tmux" && record.tmuxSession) {
     console.log(
       `note: this UI is owned by tmux session "${record.tmuxSession}". Killing the bun process — tmux will close the window.`,
+    );
+    console.log(
+      `      (or close it via tmux: \`tmux kill-window -t ${record.tmuxSession}:octopus-ui\`)`,
     );
   }
 
@@ -325,7 +359,11 @@ async function runUiStop(argv: string[]): Promise<void> {
 }
 
 async function runUiRestart(argv: string[]): Promise<void> {
-  await runUiStop([]);
+  // Forward --timeout to the stop phase so `octopus ui restart --timeout 500`
+  // applies that bound to the stop, not just the (ignored) start.
+  const { flags } = parseFlags(argv, ["timeout"]);
+  const stopArgv = flags["timeout"] ? ["--timeout", String(flags["timeout"])] : [];
+  await runUiStop(stopArgv);
   await runUiStart(argv);
 }
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,19 +1,355 @@
+import { existsSync, mkdirSync, openSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { parseFlags } from "./flags.ts";
+import {
+  isPortHeld,
+  isProcessAlive,
+  pidFilePath,
+  probeOctopusUi,
+  readPidFile,
+  removePidFile,
+  writePidFile,
+  type UiMode,
+  type UiPidRecord,
+} from "../ui/pidfile.ts";
+
+// Flags accepted by `octopus ui` and friends. Kept in one place so all paths
+// (start, stop, restart, the daemon-respawn child) parse consistently.
+const UI_FLAGS = [
+  "team",
+  "team-config",
+  "port",
+  "host",
+  "poll-ms",
+  "foreground",
+  "tmux-session",
+] as const;
+
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_PORT = 6061;
+
+interface UiOptions {
+  team?: string;
+  teamConfig?: string;
+  port: number;
+  host: string;
+  pollMs?: string;
+  foreground: boolean;
+  tmuxSession?: string;
+  /** The flags as originally given on argv, so we can re-pass them to a child. */
+  passthroughArgv: string[];
+}
+
+function readOptions(argv: string[]): UiOptions {
+  const { flags } = parseFlags(argv, [...UI_FLAGS]);
+  // Reconstruct a minimal passthrough argv (only the flags we know — drops
+  // unrelated tokens, which is fine because there are no positionals here).
+  const passthrough: string[] = [];
+  for (const name of UI_FLAGS) {
+    const v = flags[name];
+    if (v === undefined) continue;
+    if (v === true) passthrough.push(`--${name}`);
+    else passthrough.push(`--${name}`, String(v));
+  }
+  return {
+    team: flags["team"] ? String(flags["team"]) : process.env.OCTOPUS_TEAM,
+    teamConfig: flags["team-config"]
+      ? String(flags["team-config"])
+      : process.env.OCTOPUS_TEAM_CONFIG,
+    port: Number(flags["port"] ?? process.env.OCTOPUS_UI_PORT ?? DEFAULT_PORT),
+    host: String(flags["host"] ?? process.env.OCTOPUS_UI_HOST ?? DEFAULT_HOST),
+    pollMs: flags["poll-ms"] ? String(flags["poll-ms"]) : process.env.OCTOPUS_UI_POLL_MS,
+    foreground: flags["foreground"] === true,
+    tmuxSession: flags["tmux-session"] ? String(flags["tmux-session"]) : undefined,
+    passthroughArgv: passthrough,
+  };
+}
+
+function applyEnv(opts: UiOptions): void {
+  if (opts.team) process.env.OCTOPUS_TEAM = opts.team;
+  if (opts.teamConfig) process.env.OCTOPUS_TEAM_CONFIG = opts.teamConfig;
+  process.env.OCTOPUS_UI_PORT = String(opts.port);
+  process.env.OCTOPUS_UI_HOST = opts.host;
+  if (opts.pollMs) process.env.OCTOPUS_UI_POLL_MS = opts.pollMs;
+}
+
+function displayUrl(host: string, port: number): string {
+  const h = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  return `http://${h}:${port}`;
+}
+
+function logFilePath(): string {
+  const xdg = process.env.XDG_STATE_HOME?.trim();
+  const root = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "state");
+  return join(root, "octopus", "ui.log");
+}
 
 export async function runUi(argv: string[]): Promise<void> {
-  const { flags } = parseFlags(argv, ["team", "team-config", "port", "host", "poll-ms"]);
-
-  // Push CLI flags into env so the embedded server picks them up — keeps the
-  // server module env-driven (it doesn't need to know the CLI exists).
-  if (flags["team"]) process.env.OCTOPUS_TEAM = String(flags["team"]);
-  if (flags["team-config"]) process.env.OCTOPUS_TEAM_CONFIG = String(flags["team-config"]);
-  if (flags["port"]) process.env.OCTOPUS_UI_PORT = String(flags["port"]);
-  if (flags["host"]) process.env.OCTOPUS_UI_HOST = String(flags["host"]);
-  if (flags["poll-ms"]) process.env.OCTOPUS_UI_POLL_MS = String(flags["poll-ms"]);
-
-  const { app } = await import("../ui/server.tsx");
-  const port = Number(process.env.OCTOPUS_UI_PORT ?? 6061);
-  const host = process.env.OCTOPUS_UI_HOST ?? "127.0.0.1";
-  console.log(`🐙 octopus → http://${host}:${port}`);
-  Bun.serve({ fetch: app.fetch, port, hostname: host, idleTimeout: 0 });
+  const [first, ...rest] = argv;
+  if (first === "stop") return runUiStop(rest);
+  if (first === "restart") return runUiRestart(rest);
+  if (first === "status") return runUiStatus(rest);
+  return runUiStart(argv);
 }
+
+async function alreadyRunning(opts: UiOptions): Promise<UiPidRecord | null> {
+  const existing = readPidFile();
+  if (existing && isProcessAlive(existing.pid)) {
+    const probe = await probeOctopusUi(existing.host, existing.port);
+    if (probe) return existing;
+  } else if (existing) {
+    removePidFile(); // stale
+  }
+  // Fall back to a port probe in case someone started a UI without writing a
+  // PID file (older octopus version, or running directly with `bun src/...`).
+  if (await isPortHeld(opts.host, opts.port)) {
+    const probe = await probeOctopusUi(opts.host, opts.port);
+    if (probe) {
+      return {
+        pid: probe.pid,
+        host: opts.host,
+        port: opts.port,
+        startedAt: "(unknown — no PID file)",
+        mode: "foreground",
+      };
+    }
+    // Port held by something foreign — surfaced as an error in the caller.
+    return null;
+  }
+  return null;
+}
+
+async function runUiStart(argv: string[]): Promise<void> {
+  const opts = readOptions(argv);
+
+  // 1. If something is already serving as us, don't fight it.
+  const running = await alreadyRunning(opts);
+  if (running) {
+    console.log(
+      `🐙 octopus UI already running (pid ${running.pid}, mode ${running.mode}) → ${displayUrl(running.host, running.port)}`,
+    );
+    if (running.mode === "tmux" && running.tmuxSession) {
+      console.log(`   owned by tmux session "${running.tmuxSession}".`);
+    } else {
+      console.log(`   stop it with: octopus ui stop`);
+    }
+    return;
+  }
+
+  // 2. Foreign-process check: port held but not by an octopus UI.
+  if (await isPortHeld(opts.host, opts.port)) {
+    console.error(
+      `error: port ${opts.port} on ${opts.host} is held by a non-octopus process.`,
+    );
+    console.error(`Pick a different port with --port, or free the existing one.`);
+    process.exit(1);
+  }
+
+  // 3. Foreground mode runs the server in this process. Used for dev
+  //    (`bun src/cli.ts ui --foreground`) and as the body of the daemon
+  //    re-spawn / the tmux-window child.
+  if (opts.foreground) {
+    return runForeground(opts);
+  }
+
+  // 4. Default: daemonize. Spawn ourselves with --foreground and exit so the
+  //    user's shell isn't holding the server. Logs go to the state dir.
+  return spawnDaemon(opts);
+}
+
+async function runForeground(opts: UiOptions): Promise<void> {
+  applyEnv(opts);
+  const { app } = await import("../ui/server.tsx");
+
+  let server: { stop: (closeActiveConnections?: boolean) => Promise<void> } | undefined;
+  try {
+    server = Bun.serve({
+      fetch: app.fetch,
+      port: opts.port,
+      hostname: opts.host,
+      idleTimeout: 0,
+    }) as unknown as { stop: (closeActiveConnections?: boolean) => Promise<void> };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EADDRINUSE") {
+      const probe = await probeOctopusUi(opts.host, opts.port);
+      if (probe) {
+        console.log(
+          `🐙 octopus UI raced into existence (pid ${probe.pid}) → ${displayUrl(opts.host, opts.port)}`,
+        );
+        return;
+      }
+      console.error(`error: port ${opts.port} on ${opts.host} is in use.`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const mode: UiMode = opts.tmuxSession
+    ? "tmux"
+    : process.env.OCTOPUS_UI_DAEMONIZED === "1"
+      ? "daemon"
+      : "foreground";
+  const record: UiPidRecord = {
+    pid: process.pid,
+    host: opts.host,
+    port: opts.port,
+    startedAt: new Date().toISOString(),
+    mode,
+    ...(opts.tmuxSession ? { tmuxSession: opts.tmuxSession } : {}),
+  };
+  writePidFile(record);
+
+  const cleanup = (signal: string) => {
+    removePidFile();
+    void server?.stop(true).finally(() => {
+      process.exit(signal === "SIGTERM" || signal === "SIGINT" ? 0 : 1);
+    });
+  };
+  process.on("SIGTERM", () => cleanup("SIGTERM"));
+  process.on("SIGINT", () => cleanup("SIGINT"));
+  process.on("exit", () => removePidFile());
+
+  console.log(`🐙 octopus → ${displayUrl(opts.host, opts.port)}  (pid ${process.pid}, mode ${mode})`);
+  if (opts.host === "0.0.0.0" || opts.host === "::") {
+    console.log(`   bound to ${opts.host} — gate at the network layer (Tailscale, firewall).`);
+  }
+}
+
+function spawnDaemon(opts: UiOptions): void {
+  const log = logFilePath();
+  mkdirSync(dirname(log), { recursive: true });
+  const fd = openSync(log, "a");
+
+  // Use Node's spawn for proper detach + unref. Bun.spawn doesn't expose
+  // detached: true cleanly across versions.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { spawn } = require("node:child_process") as typeof import("node:child_process");
+
+  const args = [process.argv[1], "ui", "--foreground", ...opts.passthroughArgv];
+  const child = spawn(process.execPath, args, {
+    detached: true,
+    stdio: ["ignore", fd, fd],
+    env: { ...process.env, OCTOPUS_UI_DAEMONIZED: "1" },
+  });
+  child.unref();
+
+  console.log(`🐙 octopus UI starting in background → ${displayUrl(opts.host, opts.port)}`);
+  console.log(`   logs: ${log}`);
+  console.log(`   pid:  ${child.pid} (manage with: octopus ui status / stop / restart)`);
+}
+
+async function runUiStop(argv: string[]): Promise<void> {
+  const { flags } = parseFlags(argv, ["timeout"]);
+  const timeoutMs = Number(flags["timeout"] ?? 3000);
+
+  const record = readPidFile();
+  if (!record) {
+    console.log("no octopus UI PID file found — nothing to stop.");
+    return;
+  }
+
+  if (!isProcessAlive(record.pid)) {
+    console.log(`stale PID file (pid ${record.pid} no longer running) — cleaning up.`);
+    removePidFile();
+    if (await isPortHeld(record.host, record.port)) {
+      const probe = await probeOctopusUi(record.host, record.port);
+      if (probe) {
+        console.log(
+          `   note: another octopus UI (pid ${probe.pid}) is on ${displayUrl(record.host, record.port)}.`,
+        );
+      } else {
+        console.log(
+          `   note: ${record.host}:${record.port} is held by a non-octopus process.`,
+        );
+      }
+    }
+    return;
+  }
+
+  // PID alive — verify it self-identifies as us before signaling.
+  const probe = await probeOctopusUi(record.host, record.port);
+  if (!probe || probe.pid !== record.pid) {
+    if (await isPortHeld(record.host, record.port)) {
+      console.error(
+        `error: PID ${record.pid} is alive but ${record.host}:${record.port} is held by a non-octopus process.`,
+      );
+      console.error(`Refusing to kill PID ${record.pid} — please investigate.`);
+      process.exit(1);
+    }
+    console.log(
+      `PID ${record.pid} is alive but no octopus UI is responding on ${record.host}:${record.port}.`,
+    );
+    console.log(`Sending SIGTERM anyway (recorded as octopus UI in PID file).`);
+  }
+
+  if (record.mode === "tmux" && record.tmuxSession) {
+    console.log(
+      `note: this UI is owned by tmux session "${record.tmuxSession}". Killing the bun process — tmux will close the window.`,
+    );
+  }
+
+  try {
+    process.kill(record.pid, "SIGTERM");
+  } catch (err) {
+    console.error(`error: failed to signal pid ${record.pid}: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(record.pid)) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  if (isProcessAlive(record.pid)) {
+    console.error(`pid ${record.pid} did not exit within ${timeoutMs}ms — sending SIGKILL.`);
+    try {
+      process.kill(record.pid, "SIGKILL");
+    } catch {
+      // Process may have died between the check and the kill.
+    }
+  }
+
+  // Wait for the port to actually free.
+  const portDeadline = Date.now() + 1000;
+  while (Date.now() < portDeadline && (await isPortHeld(record.host, record.port))) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  removePidFile();
+  console.log(
+    `stopped octopus UI (pid ${record.pid}, was on ${displayUrl(record.host, record.port)}).`,
+  );
+}
+
+async function runUiRestart(argv: string[]): Promise<void> {
+  await runUiStop([]);
+  await runUiStart(argv);
+}
+
+async function runUiStatus(_argv: string[]): Promise<void> {
+  const record = readPidFile();
+  if (!record) {
+    console.log("no octopus UI running (no PID file).");
+    console.log(`   pidfile: ${pidFilePath()}`);
+    console.log(`   logs:    ${logFilePath()} ${existsSync(logFilePath()) ? "" : "(none yet)"}`);
+    return;
+  }
+  const alive = isProcessAlive(record.pid);
+  const probe = alive ? await probeOctopusUi(record.host, record.port) : null;
+  console.log(`pid:        ${record.pid} ${alive ? "(alive)" : "(stale)"}`);
+  console.log(`url:        ${displayUrl(record.host, record.port)}`);
+  console.log(`mode:       ${record.mode}${record.tmuxSession ? ` (tmux: ${record.tmuxSession})` : ""}`);
+  console.log(`startedAt:  ${record.startedAt}`);
+  console.log(`responding: ${probe ? "yes" : "no"}`);
+  console.log(`pidfile:    ${pidFilePath()}`);
+  console.log(`logs:       ${logFilePath()}`);
+}
+
+/**
+ * Exposed for `octopus launch` to call after creating the tmux session, so
+ * the UI window inherits the same lifecycle as the team-lead.
+ */
+export { logFilePath };

--- a/src/ui/pidfile.ts
+++ b/src/ui/pidfile.ts
@@ -1,0 +1,141 @@
+// PID-file + port-probe helpers for managing the UI process lifecycle.
+//
+// The CLI uses these to detect whether another octopus UI is already running
+// before binding (so `octopus ui` can no-op politely on EADDRINUSE), and to
+// implement `octopus ui stop` cleanly.
+//
+// The PID file lives under XDG state ($XDG_STATE_HOME or ~/.local/state) so
+// it survives across shells but is clearly transient state, not config.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type UiMode = "tmux" | "daemon" | "foreground";
+
+export interface UiPidRecord {
+  pid: number;
+  host: string;
+  port: number;
+  startedAt: string;
+  /**
+   * How this UI was launched. Drives messaging in `ui stop` / `ui status`:
+   *   - "tmux"       — owned by an `octopus launch` tmux session
+   *   - "daemon"     — backgrounded by `octopus ui` (the default)
+   *   - "foreground" — running attached to a terminal (`octopus ui --foreground`)
+   */
+  mode: UiMode;
+  /** When mode === "tmux", the tmux session that owns this UI. */
+  tmuxSession?: string;
+}
+
+export function pidFilePath(): string {
+  const xdg = process.env.XDG_STATE_HOME?.trim();
+  const root = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "state");
+  return join(root, "octopus", "ui.pid");
+}
+
+export function readPidFile(path = pidFilePath()): UiPidRecord | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf8");
+    const data = JSON.parse(raw) as Partial<UiPidRecord>;
+    if (
+      typeof data.pid !== "number" ||
+      typeof data.host !== "string" ||
+      typeof data.port !== "number" ||
+      typeof data.startedAt !== "string"
+    ) {
+      return null;
+    }
+    const mode: UiMode =
+      data.mode === "tmux" || data.mode === "daemon" || data.mode === "foreground"
+        ? data.mode
+        : "foreground";
+    return {
+      pid: data.pid,
+      host: data.host,
+      port: data.port,
+      startedAt: data.startedAt,
+      mode,
+      ...(typeof data.tmuxSession === "string" ? { tmuxSession: data.tmuxSession } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writePidFile(record: UiPidRecord, path = pidFilePath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  // Atomic-ish: write to .tmp then rename, so a crash mid-write can't leave
+  // a half-written file that parses but lies.
+  const tmp = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(record, null, 2));
+  renameSync(tmp, path);
+}
+
+export function removePidFile(path = pidFilePath()): void {
+  if (existsSync(path)) rmSync(path, { force: true });
+}
+
+/** Returns true if a process with the given PID is currently alive. */
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH = no such process; EPERM = exists but we can't signal it (still alive).
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * TCP-probe a host:port. Resolves true if something accepted the connection
+ * within the timeout. Used as a cheap "is the port held?" check before we
+ * even try to identify the holder.
+ */
+export async function isPortHeld(host: string, port: number, timeoutMs = 500): Promise<boolean> {
+  const { connect } = await import("node:net");
+  return new Promise<boolean>((resolve) => {
+    // Connecting to 0.0.0.0 is undefined on some stacks; probe loopback instead.
+    const probeHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+    const socket = connect({ host: probeHost, port, timeout: timeoutMs });
+    let settled = false;
+    const done = (held: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(held);
+    };
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+  });
+}
+
+/**
+ * Hits the UI's /api/health endpoint and returns the parsed body if it
+ * responds and self-identifies as an octopus UI. Returns null otherwise —
+ * either the port is held by something else, or by an older octopus build
+ * that lacks the endpoint.
+ */
+export async function probeOctopusUi(
+  host: string,
+  port: number,
+  timeoutMs = 800,
+): Promise<{ pid: number } | null> {
+  const probeHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    const res = await fetch(`http://${probeHost}:${port}/api/health`, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const body = (await res.json()) as { name?: string; pid?: number };
+    if (body?.name !== "octopus-ui" || typeof body.pid !== "number") return null;
+    return { pid: body.pid };
+  } catch {
+    return null;
+  }
+}

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -10,7 +10,10 @@ import { DashboardPage, PanePage } from "./render.tsx";
 import { resolvePublicDir, resolveSpawnTargetRoots, resolveTeamConfigPath } from "../paths.ts";
 
 const PORT = Number(process.env.OCTOPUS_UI_PORT ?? 6061);
-// Bind to loopback by default — opt into wider exposure with OCTOPUS_UI_HOST=0.0.0.0.
+// HOST/PORT here are fallbacks for direct invocation (`bun src/ui/server.tsx`).
+// In normal operation the CLI sets OCTOPUS_UI_HOST before importing this
+// module — and the CLI's default is 0.0.0.0, not 127.0.0.1. Don't take this
+// fallback as the product default.
 const HOST = process.env.OCTOPUS_UI_HOST ?? "127.0.0.1";
 const POLL_MS = Number(process.env.OCTOPUS_UI_POLL_MS ?? 2000);
 const TEAM_NAME = process.env.OCTOPUS_TEAM ?? "octopus";

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from "hono";
-import { serveStatic } from "hono/bun";
+import { join as joinPath } from "node:path";
 import { streamSSE } from "hono/streaming";
 import { readdir, stat } from "node:fs/promises";
-import { join, resolve as resolvePath } from "node:path";
+import { resolve as resolvePath } from "node:path";
 import { buildSnapshot, loadConfig, setConfigPath, snapshotForTentacle } from "./state.ts";
 import { capturePane, isPrimarySessionPane, isValidKey, listPanes, sendKey, sendKeys } from "./tmux.ts";
 import { DashboardPage, PanePage } from "./render.tsx";
@@ -308,9 +308,16 @@ app.get("/favicon.svg", (c) => {
   );
 });
 
-app.get("/styles.css", serveStatic({ path: join(PUBLIC_DIR, "styles.css") }));
-app.get("/app.js", serveStatic({ path: join(PUBLIC_DIR, "app.js") }));
-app.get("/pane.js", serveStatic({ path: join(PUBLIC_DIR, "pane.js") }));
+function serveFile(name: string, ct: string) {
+  const abs = joinPath(PUBLIC_DIR, name);
+  return (c: any) => {
+    c.header("Content-Type", ct);
+    return c.body(Bun.file(abs));
+  };
+}
+app.get("/styles.css", serveFile("styles.css", "text/css; charset=utf-8"));
+app.get("/app.js", serveFile("app.js", "text/javascript; charset=utf-8"));
+app.get("/pane.js", serveFile("pane.js", "text/javascript; charset=utf-8"));
 
 function renderError(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -51,6 +51,13 @@ app.get("/api/state", async (c) => {
   return c.json(snap);
 });
 
+// Identifies this process as an octopus UI. Used by the CLI to decide whether
+// a held port belongs to us (no-op on `octopus ui`) or a foreign process
+// (refuse to act in `octopus ui stop`).
+app.get("/api/health", (c) => {
+  return c.json({ name: "octopus-ui", pid: process.pid });
+});
+
 app.get("/api/pane/:name", async (c) => {
   const name = c.req.param("name");
   const lines = Number(c.req.query("lines") ?? 300);

--- a/src/ui/state.ts
+++ b/src/ui/state.ts
@@ -86,8 +86,16 @@ const PRIMARY_CACHE_TTL_MS = 30_000;
 let primaryCache: { paneId: string; at: number } | null = null;
 
 export async function loadConfig(path: string = currentConfigPath): Promise<TeamConfig> {
-  const raw = await readFile(path, "utf8");
-  return JSON.parse(raw) as TeamConfig;
+  try {
+    const raw = await readFile(path, "utf8");
+    return JSON.parse(raw) as TeamConfig;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      console.log(`team config not found at ${path}; dashboard will populate when team is created`);
+      return { name: "octopus", createdAt: Date.now(), members: [] };
+    }
+    throw err;
+  }
 }
 
 export function shortCwd(cwd: string): string {

--- a/tests/pidfile.test.ts
+++ b/tests/pidfile.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createServer, type Server } from "node:net";
+import { join } from "node:path";
+import {
+  isPortHeld,
+  isProcessAlive,
+  pidFilePath,
+  probeOctopusUi,
+  readPidFile,
+  removePidFile,
+  writePidFile,
+  type UiPidRecord,
+} from "../src/ui/pidfile.ts";
+
+describe("pidFilePath", () => {
+  let savedXdg: string | undefined;
+  beforeEach(() => {
+    savedXdg = process.env.XDG_STATE_HOME;
+  });
+  afterEach(() => {
+    if (savedXdg === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdg;
+  });
+
+  test("uses XDG_STATE_HOME when set", () => {
+    process.env.XDG_STATE_HOME = "/tmp/xdg-state";
+    expect(pidFilePath()).toBe("/tmp/xdg-state/octopus/ui.pid");
+  });
+
+  test("falls back to ~/.local/state when XDG unset", () => {
+    delete process.env.XDG_STATE_HOME;
+    expect(pidFilePath()).toMatch(/\/\.local\/state\/octopus\/ui\.pid$/);
+  });
+
+  test("treats empty XDG_STATE_HOME as unset", () => {
+    process.env.XDG_STATE_HOME = "  ";
+    expect(pidFilePath()).toMatch(/\/\.local\/state\/octopus\/ui\.pid$/);
+  });
+});
+
+describe("write/read/remove PID file", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "octopus-pid-"));
+    path = join(dir, "ui.pid");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("round-trips a record", () => {
+    const record: UiPidRecord = {
+      pid: 12345,
+      host: "0.0.0.0",
+      port: 6061,
+      startedAt: "2026-04-15T10:00:00.000Z",
+      mode: "daemon",
+    };
+    writePidFile(record, path);
+    expect(readPidFile(path)).toEqual(record);
+  });
+
+  test("preserves tmuxSession when present", () => {
+    const record: UiPidRecord = {
+      pid: 999,
+      host: "127.0.0.1",
+      port: 6061,
+      startedAt: "2026-04-15T10:00:00.000Z",
+      mode: "tmux",
+      tmuxSession: "octopus",
+    };
+    writePidFile(record, path);
+    expect(readPidFile(path)?.tmuxSession).toBe("octopus");
+  });
+
+  test("returns null on missing file", () => {
+    expect(readPidFile(path)).toBeNull();
+  });
+
+  test("returns null on garbage JSON", () => {
+    writeFileSync(path, "not json");
+    expect(readPidFile(path)).toBeNull();
+  });
+
+  test("returns null when required fields missing", () => {
+    writeFileSync(path, JSON.stringify({ pid: 1 }));
+    expect(readPidFile(path)).toBeNull();
+  });
+
+  test("defaults missing/invalid mode to 'foreground'", () => {
+    writeFileSync(
+      path,
+      JSON.stringify({ pid: 1, host: "x", port: 1, startedAt: "t" }),
+    );
+    expect(readPidFile(path)?.mode).toBe("foreground");
+    writeFileSync(
+      path,
+      JSON.stringify({ pid: 1, host: "x", port: 1, startedAt: "t", mode: "bogus" }),
+    );
+    expect(readPidFile(path)?.mode).toBe("foreground");
+  });
+
+  test("write is atomic — readable JSON exists at target", () => {
+    writePidFile(
+      { pid: 1, host: "x", port: 1, startedAt: "t", mode: "daemon" },
+      path,
+    );
+    expect(JSON.parse(readFileSync(path, "utf8")).pid).toBe(1);
+  });
+
+  test("remove is idempotent", () => {
+    removePidFile(path);
+    writePidFile({ pid: 1, host: "x", port: 1, startedAt: "t", mode: "daemon" }, path);
+    removePidFile(path);
+    removePidFile(path);
+    expect(readPidFile(path)).toBeNull();
+  });
+});
+
+describe("isProcessAlive", () => {
+  test("true for our own PID", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  test("false for an obviously bogus PID", () => {
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    // PID 999999 is almost certainly not in use.
+    expect(isProcessAlive(999999)).toBe(false);
+  });
+});
+
+describe("isPortHeld + probeOctopusUi", () => {
+  let server: Server | null = null;
+  let port = 0;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((r) => server!.close(() => r()));
+      server = null;
+    }
+  });
+
+  test("isPortHeld false when nothing is listening", async () => {
+    expect(await isPortHeld("127.0.0.1", 1, 200)).toBe(false);
+  });
+
+  test("isPortHeld true when something is listening", async () => {
+    server = createServer();
+    await new Promise<void>((r) => server!.listen(0, "127.0.0.1", () => r()));
+    port = (server.address() as { port: number }).port;
+    expect(await isPortHeld("127.0.0.1", port, 500)).toBe(true);
+  });
+
+  test("probeOctopusUi returns null for non-octopus listener", async () => {
+    server = createServer((sock) => sock.end());
+    await new Promise<void>((r) => server!.listen(0, "127.0.0.1", () => r()));
+    port = (server.address() as { port: number }).port;
+    expect(await probeOctopusUi("127.0.0.1", port, 300)).toBeNull();
+  });
+
+  test("probeOctopusUi returns null when nothing is listening", async () => {
+    expect(await probeOctopusUi("127.0.0.1", 1, 200)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the orphan-UI-on-port-6061 problem by giving the UI a proper lifecycle. Aaron picked **shape C** from the design discussion (in [feat/ui-lifecycle](../tree/feat/ui-lifecycle) thread): one tmux session owns both the team-lead and the UI; standalone `octopus ui` daemonizes by default with full lifecycle subcommands.

### Behavior changes (worth calling out explicitly)

1. **`octopus launch` now spawns the UI as a managed window in its tmux session** (named `octopus-ui`). Kill the session, both the team-lead and the UI die. No orphan processes possible. Pass `--no-ui` to opt out.
2. **`octopus ui` (standalone) daemonizes by default.** Logs to `~/.local/state/octopus/ui.log`. Idempotent — if a UI is already running, prints the URL and exits 0 instead of crashing on `EADDRINUSE`. Use `--foreground` for dev mode.
3. **Default `--host` flips from `127.0.0.1` → `0.0.0.0`.** Matches Aaron's actual Tailscale-gated usage. Network-layer is the auth boundary; `--host 127.0.0.1` restricts to loopback.
4. **New subcommands:** `octopus ui stop`, `octopus ui restart`, `octopus ui status`. Stop refuses to kill the recorded PID if it now belongs to a non-octopus process; cleans up stale PID files automatically.

Minor version bump: `0.1.0 → 0.2.0`.

## Design

- **PID file** at `${XDG_STATE_HOME:-~/.local/state}/octopus/ui.pid` records `{pid, host, port, startedAt, mode, tmuxSession?}`. Atomic write (`.tmp` → rename).
- **`/api/health`** returns `{name: "octopus-ui", pid}` so the CLI can distinguish "another octopus UI" from "a foreign process holding the port" before acting.
- **`stop` is layered defensively**: PID-alive check → health probe with PID match → only then SIGTERM, with SIGKILL fallback after timeout. If PID is alive but doesn't respond as us (likely OS PID reuse after a crash that bypassed our cleanup handler), we remove the stale PID file but **do not signal** the process — refusing to risk killing something unrelated.
- **Self-review** via the `reviewer` subagent caught one must-fix (the PID-reuse hazard above) and several polish items, all applied in commit 4.

## Test plan
- [x] `bun test` — 50/50 pass (was 33; 17 new in `tests/pidfile.test.ts`)
- [x] `tsc --noEmit` clean
- [x] Manual smoke: `ui` (daemonize) → `ui status` (reports immediately, no race) → `ui` again (idempotent, points at running) → `ui stop` (clean exit, port freed)
- [x] Manual smoke: `/api/health` returns expected JSON
- [ ] **Aaron**: try `octopus launch` end-to-end and confirm both the team-lead and the UI window come up in the tmux session, and that killing the session takes both down

## Notes
- This is a **behavior shift** for existing users: `octopus launch` now does more than before (spawns UI), and the UI's default host changed. Documented in README.
- `octopus ui status` and `octopus ui stop` work uniformly across all three modes (tmux / daemon / foreground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)