### PR TITLE
Unify main: cherry-pick resume feature + instance param threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Bootstrap the current repo. Writes:
 Idempotent: re-running overwrites the four template files but preserves the
 rest of `CLAUDE.md`. Default team name is `octopus`.
 
-### `octopus launch [--team <name>] [--cwd <path>] [--session <name>] [--model <id>] [--no-ui] [--ui-port <n>] [--ui-host <addr>]`
+### `octopus launch [<name>] [--team <name>] [--cwd <path>] [--session <name>] [--model <id>] [--continue | --resume <session-id>] [--no-ui]`
 
 Start (or attach to) a tmux session running Claude Code as the team-lead, and
 **spawn the web UI as a managed window in the same tmux session**. One tmux
@@ -96,6 +96,14 @@ Defaults: team `octopus`, cwd `$PWD`, session name = team name. Inside an
 existing tmux session it does `switch-client` instead of `attach`. Pass
 `--no-ui` to skip the UI window (useful in dev when you want to run the UI
 yourself with `bun --hot`).
+
+Pass `--continue` to resume the most recent Claude Code session for the
+cwd, or `--resume <session-id>` for a specific one. Mutually exclusive;
+ignored (with a warning) if the tmux session already exists.
+
+### `octopus sessions [--cwd <path>]`
+
+List recent Claude Code sessions for the current cwd so you can pick one to resume.
 
 ### `octopus ui [--team <name>] [--port 6061] [--host 0.0.0.0] [--team-config <path>] [--foreground]`
 

--- a/public/app.js
+++ b/public/app.js
@@ -25,6 +25,16 @@ const colorMap = {
   slate: "#9B9590",
 };
 
+// Instance param — carried through to all pane links and API calls.
+const instanceParam = new URLSearchParams(window.location.search).get("instance");
+function paneUrl(name) {
+  const base = `/pane/${encodeURIComponent(name)}`;
+  return instanceParam ? `${base}?instance=${encodeURIComponent(instanceParam)}` : base;
+}
+function apiUrl(path) {
+  return instanceParam ? `${path}${path.includes("?") ? "&" : "?"}instance=${encodeURIComponent(instanceParam)}` : path;
+}
+
 function colorFor(name) {
   return colorMap[name] ?? colorMap.slate;
 }
@@ -92,7 +102,7 @@ function renderCard(t, compact) {
     <div><dt>joined</dt><dd>${formatJoinedAt(t.joinedAt)}</dd></div>
   </dl>
   ${tailHtml(t)}
-  <footer class="card-foot"><a class="btn btn-primary" href="/pane/${encodeURIComponent(t.name)}">open</a></footer>
+  <footer class="card-foot"><a class="btn btn-primary" href="${paneUrl(t.name)}">open</a></footer>
 </article>`;
 }
 
@@ -118,7 +128,7 @@ function renderHero(t) {
   </div>
 </div>
 <pre class="hero-tail" aria-label="recent output from ${escapeHtml(t.name)}">${tailContent}</pre>
-<a class="btn btn-primary hero-open" href="/pane/${encodeURIComponent(t.name)}">open</a>`;
+<a class="btn btn-primary hero-open" href="${paneUrl(t.name)}">open</a>`;
 }
 
 // Keep in sync with src/render.tsx OctopusGlyph.
@@ -249,7 +259,7 @@ let es;
 let retry = 0;
 
 function connect() {
-  es = new EventSource("/api/stream");
+  es = new EventSource(apiUrl("/api/stream"));
   es.addEventListener("state", (ev) => {
     retry = 0;
     if (refreshIndicator) {
@@ -279,7 +289,7 @@ connect();
 
 async function manualRefresh() {
   try {
-    const r = await fetch("/api/state", { cache: "no-store" });
+    const r = await fetch(apiUrl("/api/state"), { cache: "no-store" });
     if (!r.ok) throw new Error(String(r.status));
     applyState(await r.json());
   } catch (err) {
@@ -426,7 +436,7 @@ let targetsLoaded = false;
 async function loadSpawnTargets() {
   if (targetsLoaded || !targetList) return;
   try {
-    const r = await fetch("/api/spawn-targets");
+    const r = await fetch(apiUrl("/api/spawn-targets"));
     const { targets } = await r.json();
     targetList.innerHTML = (targets ?? [])
       .map((t) => `<option value="${escapeHtml(t)}"></option>`)
@@ -472,7 +482,7 @@ spawnForm?.addEventListener("submit", async (e) => {
   submit.disabled = true;
   if (body.cloneUrl) submit.textContent = "cloning…";
   try {
-    const res = await fetch("/api/spawn", {
+    const res = await fetch(apiUrl("/api/spawn"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -583,7 +593,7 @@ function atBottom(el) {
 function openSplit(name) {
   if (isMobile()) {
     // On mobile, fall back to navigate-away
-    window.location.href = `/pane/${encodeURIComponent(name)}`;
+    window.location.href = paneUrl(name);
     return;
   }
   if (activeSplitArm === name) {
@@ -607,7 +617,7 @@ function openSplit(name) {
   splitMeta.textContent = "";
   splitStatusDot.className = "status-dot";
   splitScrollback.textContent = "(loading…)";
-  splitExpand.href = `/pane/${encodeURIComponent(name)}`;
+  splitExpand.href = paneUrl(name);
 
   // Highlight active card
   grid?.querySelectorAll(".card").forEach((el) => {
@@ -619,7 +629,7 @@ function openSplit(name) {
   let retries = 0;
 
   function connectPane() {
-    splitEs = new EventSource(`/api/stream/pane/${encodeURIComponent(name)}`);
+    splitEs = new EventSource(apiUrl(`/api/stream/pane/${encodeURIComponent(name)}`));
     splitEs.addEventListener("pane", (ev) => {
       retries = 0;
       try {
@@ -699,7 +709,7 @@ splitSendForm?.addEventListener("submit", async (e) => {
     const body = text.trim()
       ? { text, enter: true, mode: "text" }
       : { text: "Enter", mode: "key" };
-    const res = await fetch(`/api/panes/${encodeURIComponent(activeSplitArm)}/send`, {
+    const res = await fetch(apiUrl(`/api/panes/${encodeURIComponent(activeSplitArm)}/send`), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -723,7 +733,7 @@ document.querySelectorAll("[data-split-key]").forEach((btn) => {
   btn.addEventListener("click", async () => {
     if (!activeSplitArm) return;
     try {
-      const res = await fetch(`/api/panes/${encodeURIComponent(activeSplitArm)}/send`, {
+      const res = await fetch(apiUrl(`/api/panes/${encodeURIComponent(activeSplitArm)}/send`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: btn.dataset.splitKey, mode: "key" }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { runInit } from "./cli/init.ts";
 import { runLaunch } from "./cli/launch.ts";
 import { runPod } from "./cli/pod.ts";
 import { runSend } from "./cli/send.ts";
+import { runSessions } from "./cli/sessions.ts";
 import { runSpawn } from "./cli/spawn.ts";
 import { runUi } from "./cli/ui.ts";
 
@@ -47,6 +48,9 @@ async function main(): Promise<void> {
       return;
     case "spawn":
       await runSpawn(rest);
+      return;
+    case "sessions":
+      await runSessions(rest);
       return;
     default:
       console.error(`unknown command: ${command}`);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -10,6 +10,7 @@ commands:
   ui              start / stop / restart the web dashboard
   pod             manage multiple octopus instances
   send <text>     send keystrokes to the team-lead pane
+  sessions        list recent Claude Code sessions for resume
 
   init            bootstrap octopus in the current repo
   spawn <n> <d>   type /spawn into the team-lead pane
@@ -33,6 +34,8 @@ function helpLaunch(): void {
   --no-ui                 skip starting the web dashboard
   --ui-port <n>           dashboard port (default: 6061)
   --ui-host <addr>        dashboard bind address (default: 0.0.0.0)
+  --continue              resume the most recent Claude Code session
+  --resume <session-id>   resume a specific session (see: sessions)
 `);
 }
 

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -16,6 +16,36 @@ import { findInstance, findInstanceByScope } from "../pod.ts";
 
 const UI_WINDOW_NAME = "octopus-ui";
 
+export interface LaunchArgOptions {
+  team: string;
+  cwd: string;
+  session: string;
+  model: string;
+  skipPermissions: boolean;
+  resume?: string;
+  continueSession?: boolean;
+}
+
+export function buildClaudeLaunchArgs(opts: LaunchArgOptions): string[] {
+  const args = [
+    "tmux",
+    "new-session",
+    "-d",
+    "-s",
+    opts.session,
+    "-c",
+    opts.cwd,
+    "-e",
+    `OCTOPUS_TEAM=${opts.team}`,
+    "claude",
+  ];
+  if (opts.skipPermissions) args.push("--dangerously-skip-permissions");
+  if (opts.model) args.push("--model", opts.model);
+  if (opts.continueSession) args.push("--continue");
+  if (opts.resume) args.push("--resume", opts.resume);
+  return args;
+}
+
 export async function runLaunch(argv: string[]): Promise<void> {
   const { flags, positional } = parseFlags(argv, [
     "team",
@@ -26,6 +56,8 @@ export async function runLaunch(argv: string[]): Promise<void> {
     "no-ui",
     "ui-port",
     "ui-host",
+    "resume",
+    "continue",
   ]);
 
   // Resolve from pod registry. Three paths:
@@ -53,12 +85,17 @@ export async function runLaunch(argv: string[]): Promise<void> {
   const cwd = resolvedCwd;
   const session = (flags.session as string) ?? team;
   const model = (flags.model as string) ?? "";
-  // Default: pass --dangerously-skip-permissions so the team-lead can dispatch
-  // freely. Opt out via --no-skip-permissions or OCTOPUS_SKIP_PERMISSIONS=false
-  // for shared / less-trusted environments.
   const skipPermissions =
     !flags["no-skip-permissions"] &&
     process.env.OCTOPUS_SKIP_PERMISSIONS !== "false";
+
+  const continueSession = flags["continue"] === true;
+  const resume = typeof flags.resume === "string" ? flags.resume : undefined;
+  if (continueSession && resume) {
+    console.error("error: --continue and --resume are mutually exclusive.");
+    console.error("Use --continue for the most recent session, --resume <id> for a specific one.");
+    process.exit(1);
+  }
 
   if (!which("tmux")) {
     console.error("error: tmux is not installed or not on PATH (try `brew install tmux`).");
@@ -75,28 +112,34 @@ export async function runLaunch(argv: string[]): Promise<void> {
   }
 
   if (tmuxHasSession(session)) {
+    if (continueSession || resume) {
+      console.warn(
+        `note: tmux session "${session}" is already running — attach flags (--continue / --resume) are ignored.`,
+      );
+      console.warn(`To start a fresh claude with resume, kill the session first: tmux kill-session -t ${session}`);
+    }
     console.log(`attaching to existing tmux session "${session}"`);
   } else {
-    const claudeArgs = [
-      "tmux",
-      "new-session",
-      "-d",
-      "-s",
-      session,
-      "-c",
+    const claudeArgs = buildClaudeLaunchArgs({
+      team,
       cwd,
-      "-e",
-      `OCTOPUS_TEAM=${team}`,
-      "claude",
-    ];
-    if (skipPermissions) claudeArgs.push("--dangerously-skip-permissions");
-    if (model) claudeArgs.push("--model", model);
+      session,
+      model,
+      skipPermissions,
+      resume,
+      continueSession,
+    });
     const create = Bun.spawnSync(claudeArgs, { stdout: "inherit", stderr: "inherit" });
     if (create.exitCode !== 0) {
       console.error("error: failed to create tmux session.");
       process.exit(create.exitCode ?? 1);
     }
-    console.log(`started octopus team "${team}" in tmux session "${session}" (cwd: ${cwd})`);
+    const resumeNote = continueSession
+      ? " (resuming most recent session)"
+      : resume
+        ? ` (resuming session ${resume.slice(0, 8)}…)`
+        : "";
+    console.log(`started octopus team "${team}" in tmux session "${session}" (cwd: ${cwd})${resumeNote}`);
   }
 
   // Bring up the UI as a managed window inside the same tmux session, unless
@@ -134,8 +177,6 @@ interface EnsureUiOpts {
 }
 
 async function ensureUiWindow(opts: EnsureUiOpts): Promise<void> {
-  // 1. If a UI is already running (anywhere — tmux, daemon, foreign), don't
-  //    spawn a second one. Point at the live one and move on.
   const existing = readPidFile();
   if (existing && isProcessAlive(existing.pid)) {
     const probe = await probeOctopusUi(existing.host, existing.port);
@@ -147,15 +188,11 @@ async function ensureUiWindow(opts: EnsureUiOpts): Promise<void> {
     }
   }
 
-  // 2. If our session already has the UI window, leave it alone (idempotent
-  //    re-launch).
   if (tmuxListWindows(opts.session).includes(UI_WINDOW_NAME)) {
     console.log(`   UI window "${UI_WINDOW_NAME}" already present in session "${opts.session}".`);
     return;
   }
 
-  // 3. Build the command. Prefer `parachute-octopus` on PATH, fall back to
-  //    `octopus`, then to invoking this same script via bun for source-tree dev.
   const flags = [
     "--foreground",
     "--tmux-session",
@@ -186,9 +223,6 @@ async function ensureUiWindow(opts: EnsureUiOpts): Promise<void> {
 }
 
 function quote(s: string): string {
-  // Shell-quote for the tmux command string. tmux runs the command via
-  // /bin/sh -c, so single-quote anything containing whitespace or shell metas.
-  // Note: `-` placed at end of class to avoid being misread as a range.
-  if (/^[a-zA-Z0-9_./@:=+-]+$/.test(s)) return s; // eslint-disable-line no-useless-escape
+  if (/^[a-zA-Z0-9_./@:=+-]+$/.test(s)) return s;
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }

--- a/src/cli/sessions.ts
+++ b/src/cli/sessions.ts
@@ -1,0 +1,124 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+import { parseFlags } from "./flags.ts";
+
+export interface SessionInfo {
+  id: string;
+  path: string;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  durationMs?: number;
+  sizeBytes: number;
+}
+
+// Claude Code encodes a project cwd into a directory name by replacing each
+// "/" with "-". So `/Users/alice/code/foo` becomes `-Users-alice-code-foo`.
+export function encodeProjectCwd(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+export function projectsRoot(): string {
+  return join(homedir(), ".claude", "projects");
+}
+
+// Scan a chunk of text for the first occurrence of a `"timestamp":"..."` value
+// and return the value (or undefined). Stops at the first match — we don't
+// need to parse the whole line.
+function firstTimestamp(text: string): string | undefined {
+  const m = text.match(/"timestamp":"([^"]+)"/);
+  return m?.[1];
+}
+
+function lastTimestamp(text: string): string | undefined {
+  const m = [...text.matchAll(/"timestamp":"([^"]+)"/g)];
+  return m.length ? m[m.length - 1]?.[1] : undefined;
+}
+
+// Read the first and last chunks of a file without loading the whole thing.
+// We scan at most HEAD_BYTES from the start and TAIL_BYTES from the end for
+// timestamp fields. Sessions with millions of entries stay cheap.
+const HEAD_BYTES = 32 * 1024;
+const TAIL_BYTES = 32 * 1024;
+
+export async function readSessionMeta(path: string): Promise<SessionInfo> {
+  const file = Bun.file(path);
+  const size = file.size;
+  const headEnd = Math.min(size, HEAD_BYTES);
+  const tailStart = Math.max(0, size - TAIL_BYTES);
+
+  const head = await file.slice(0, headEnd).text();
+  // If the file is small enough that the head already covers everything,
+  // don't read a second time — saves a syscall on short sessions.
+  const tail = tailStart < headEnd ? head : await file.slice(tailStart, size).text();
+
+  const first = firstTimestamp(head);
+  const last = lastTimestamp(tail);
+  const durationMs =
+    first && last ? new Date(last).getTime() - new Date(first).getTime() : undefined;
+
+  const id = path.split("/").pop()?.replace(/\.jsonl$/, "") ?? path;
+  return { id, path, firstTimestamp: first, lastTimestamp: last, durationMs, sizeBytes: size };
+}
+
+export async function listSessions(cwd: string, root = projectsRoot()): Promise<SessionInfo[]> {
+  const dir = join(root, encodeProjectCwd(cwd));
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const jsonls = entries.filter((e) => e.endsWith(".jsonl"));
+  const metas = await Promise.all(jsonls.map((f) => readSessionMeta(join(dir, f))));
+  // Sort by last-activity desc; sessions with no timestamp go last.
+  return metas.sort((a, b) => {
+    const ta = a.lastTimestamp ? new Date(a.lastTimestamp).getTime() : 0;
+    const tb = b.lastTimestamp ? new Date(b.lastTimestamp).getTime() : 0;
+    return tb - ta;
+  });
+}
+
+// Format a duration in ms as "2 hours", "45 min", "12 sec", etc. — imprecise
+// by design, so the output scans easily.
+export function formatDuration(ms: number): string {
+  if (ms < 0) return "—";
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return `${sec} sec of context`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min} min of context`;
+  const hr = ms / (1000 * 60 * 60);
+  if (hr < 10) return `${hr.toFixed(1)} hours of context`;
+  return `${Math.round(hr)} hours of context`;
+}
+
+// Format a timestamp like "2026-04-15 17:43" in local time.
+export function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function formatSessionsList(sessions: SessionInfo[]): string {
+  if (sessions.length === 0) {
+    return "No Claude Code sessions found for this project.\n\nStart a fresh one with: octopus launch";
+  }
+  const lines = ["Recent Claude Code sessions in this project:", ""];
+  sessions.slice(0, 10).forEach((s, i) => {
+    const when = s.lastTimestamp ? formatTimestamp(s.lastTimestamp) : "unknown time";
+    const dur = s.durationMs !== undefined ? formatDuration(s.durationMs) : "duration unknown";
+    lines.push(`  ${i + 1}. ${when}  ${dur} · ${s.id}`);
+  });
+  lines.push("");
+  lines.push("Resume the most recent with: octopus launch --continue");
+  lines.push("Resume a specific one with:  octopus launch --resume <session-id>");
+  return lines.join("\n");
+}
+
+export async function runSessions(argv: string[]): Promise<void> {
+  const { flags } = parseFlags(argv, ["cwd"]);
+  const cwd = resolve((flags.cwd as string) ?? process.cwd());
+  const sessions = await listSessions(cwd);
+  console.log(formatSessionsList(sessions));
+}

--- a/src/ui/render.tsx
+++ b/src/ui/render.tsx
@@ -4,6 +4,11 @@ import type { PodStatus } from "../pod.ts";
 import { colorFor } from "./colors.ts";
 import { formatAge, formatJoinedAt } from "./format.ts";
 
+function paneUrl(name: string, instance?: string): string {
+  const base = `/pane/${encodeURIComponent(name)}`;
+  return instance ? `${base}?instance=${encodeURIComponent(instance)}` : base;
+}
+
 interface LayoutProps {
   title: string;
   children: any;
@@ -304,7 +309,7 @@ function TailRegion({ t }: { t: Tentacle }) {
   );
 }
 
-function Card({ t, compact }: { t: Tentacle; compact?: boolean }) {
+function Card({ t, compact, instance }: { t: Tentacle; compact?: boolean; instance?: string }) {
   const accent = colorFor(t.color);
   return (
     <article
@@ -366,7 +371,7 @@ function Card({ t, compact }: { t: Tentacle; compact?: boolean }) {
       <TailRegion t={t} />
 
       <footer class="card-foot">
-        <a class="btn btn-primary" href={`/pane/${encodeURIComponent(t.name)}`}>
+        <a class="btn btn-primary" href={paneUrl(t.name, instance)}>
           open
         </a>
       </footer>
@@ -375,7 +380,7 @@ function Card({ t, compact }: { t: Tentacle; compact?: boolean }) {
 }
 
 // Hero card — horizontal banner: glyph | titles | tail | open button.
-function HeroCard({ t }: { t: Tentacle }) {
+function HeroCard({ t, instance }: { t: Tentacle; instance?: string }) {
   const accent = colorFor(t.color) || "#7AB09D";
   const tail = t.lastTail.length === 0 ? null : t.lastTail.slice(-12).join("\n");
   return (
@@ -410,7 +415,7 @@ function HeroCard({ t }: { t: Tentacle }) {
       <pre class="hero-tail" aria-label={`recent output from ${t.name}`}>
         {tail ?? <span class="quiet-line">quiet for a moment</span>}
       </pre>
-      <a class="btn btn-primary hero-open" href={`/pane/${encodeURIComponent(t.name)}`}>
+      <a class="btn btn-primary hero-open" href={paneUrl(t.name, instance)}>
         open
       </a>
     </article>
@@ -522,7 +527,7 @@ export function DashboardPage({ snap, podOctopi, activeInstance }: { snap: Snaps
             class="hero-section"
             data-mentioned={mentioned.join(",")}
           >
-            <HeroCard t={teamLead} />
+            <HeroCard t={teamLead} instance={activeInstance} />
             <ArmsLayer />
           </section>
         )}
@@ -537,7 +542,7 @@ export function DashboardPage({ snap, podOctopi, activeInstance }: { snap: Snaps
         ) : (
           <section class="grid" id="grid">
             {others.map((t) => (
-              <Card t={t} compact={compact} />
+              <Card t={t} compact={compact} instance={activeInstance} />
             ))}
           </section>
         )}

--- a/tests/launch.test.ts
+++ b/tests/launch.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { buildClaudeLaunchArgs } from "../src/cli/launch.ts";
+
+const CLI = resolve(import.meta.dir, "../src/cli.ts");
+
+describe("buildClaudeLaunchArgs", () => {
+  const base = {
+    team: "octopus",
+    cwd: "/tmp/proj",
+    session: "octopus",
+    model: "",
+    skipPermissions: true,
+  };
+
+  test("includes --continue when continueSession is set", () => {
+    const args = buildClaudeLaunchArgs({ ...base, continueSession: true });
+    expect(args).toContain("--continue");
+  });
+
+  test("includes --resume <id> when resume is set", () => {
+    const args = buildClaudeLaunchArgs({ ...base, resume: "abc-123" });
+    const idx = args.indexOf("--resume");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("abc-123");
+  });
+
+  test("omits both flags by default", () => {
+    const args = buildClaudeLaunchArgs(base);
+    expect(args).not.toContain("--continue");
+    expect(args).not.toContain("--resume");
+  });
+
+  test("model + skipPermissions + continue all stack", () => {
+    const args = buildClaudeLaunchArgs({
+      ...base,
+      model: "claude-sonnet-4-6",
+      continueSession: true,
+    });
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args).toContain("--model");
+    expect(args).toContain("claude-sonnet-4-6");
+    expect(args).toContain("--continue");
+  });
+
+  test("--continue + --resume together exits with a helpful error", async () => {
+    const proc = Bun.spawn(["bun", CLI, "launch", "--continue", "--resume", "abc"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const code = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(code).toBe(1);
+    expect(stderr).toContain("mutually exclusive");
+  });
+
+  test("uses `claude` as the launched binary after tmux new-session flags", () => {
+    const args = buildClaudeLaunchArgs(base);
+    const claudeIdx = args.indexOf("claude");
+    expect(claudeIdx).toBeGreaterThan(-1);
+    // --continue / --resume must come after the `claude` token so they reach
+    // the Claude Code CLI, not tmux.
+    const argsAfterClaude = buildClaudeLaunchArgs({ ...base, continueSession: true }).slice(claudeIdx + 1);
+    expect(argsAfterClaude).toContain("--continue");
+  });
+});

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  encodeProjectCwd,
+  formatDuration,
+  formatSessionsList,
+  formatTimestamp,
+  listSessions,
+} from "../src/cli/sessions.ts";
+
+describe("encodeProjectCwd", () => {
+  test("replaces all slashes with dashes", () => {
+    expect(encodeProjectCwd("/Users/alice/code/foo")).toBe("-Users-alice-code-foo");
+  });
+  test("leaves dash-free relative paths alone-ish", () => {
+    expect(encodeProjectCwd("relative")).toBe("relative");
+  });
+});
+
+describe("formatDuration", () => {
+  test("seconds", () => {
+    expect(formatDuration(4_000)).toBe("4 sec of context");
+  });
+  test("minutes", () => {
+    expect(formatDuration(30 * 60 * 1000)).toBe("30 min of context");
+  });
+  test("hours (with fractional)", () => {
+    expect(formatDuration(2.5 * 60 * 60 * 1000)).toBe("2.5 hours of context");
+  });
+  test("hours (rounded when > 10h)", () => {
+    expect(formatDuration(24 * 60 * 60 * 1000)).toBe("24 hours of context");
+  });
+  test("negative returns dash", () => {
+    expect(formatDuration(-5)).toBe("—");
+  });
+});
+
+describe("formatTimestamp", () => {
+  test("returns YYYY-MM-DD HH:MM shape", () => {
+    const s = formatTimestamp("2026-04-15T17:43:00.000Z");
+    expect(s).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+  test("falls back to the raw value on garbage", () => {
+    expect(formatTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("listSessions", () => {
+  test("reads session metadata from jsonl files in the encoded project dir", async () => {
+    const root = await mkdtemp(join(tmpdir(), "octopus-sessions-"));
+    const projectCwd = "/tmp/test-project-xyz";
+    const projectDir = join(root, encodeProjectCwd(projectCwd));
+    await mkdir(projectDir, { recursive: true });
+
+    // Session A — 30 min of activity
+    await writeFile(
+      join(projectDir, "aaaa-1111.jsonl"),
+      [
+        JSON.stringify({ type: "system", timestamp: "2026-04-15T10:00:00.000Z" }),
+        JSON.stringify({ type: "user", content: "hi", timestamp: "2026-04-15T10:05:00.000Z" }),
+        JSON.stringify({ type: "assistant", content: "ok", timestamp: "2026-04-15T10:30:00.000Z" }),
+      ].join("\n"),
+    );
+
+    // Session B — most recent, 2 hours of activity
+    await writeFile(
+      join(projectDir, "bbbb-2222.jsonl"),
+      [
+        JSON.stringify({ type: "system", timestamp: "2026-04-15T14:00:00.000Z" }),
+        JSON.stringify({ type: "user", content: "hi", timestamp: "2026-04-15T16:00:00.000Z" }),
+      ].join("\n"),
+    );
+
+    // Non-jsonl: should be ignored.
+    await writeFile(join(projectDir, "README.md"), "ignored");
+
+    const sessions = await listSessions(projectCwd, root);
+    expect(sessions).toHaveLength(2);
+    // Sorted by last-activity desc — session B (16:00) first
+    expect(sessions[0]?.id).toBe("bbbb-2222");
+    expect(sessions[1]?.id).toBe("aaaa-1111");
+    expect(sessions[0]?.firstTimestamp).toBe("2026-04-15T14:00:00.000Z");
+    expect(sessions[0]?.lastTimestamp).toBe("2026-04-15T16:00:00.000Z");
+    expect(sessions[0]?.durationMs).toBe(2 * 60 * 60 * 1000);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("returns empty list when the project dir doesn't exist", async () => {
+    const sessions = await listSessions("/nonexistent/path/abc", "/tmp/definitely-not-here-xyz");
+    expect(sessions).toEqual([]);
+  });
+});
+
+describe("formatSessionsList", () => {
+  test("friendly empty message", () => {
+    const out = formatSessionsList([]);
+    expect(out).toContain("No Claude Code sessions found");
+    expect(out).toContain("octopus launch");
+  });
+
+  test("includes id, last-touched, duration, and the resume hints", () => {
+    const out = formatSessionsList([
+      {
+        id: "abcd-1234",
+        path: "/fake",
+        firstTimestamp: "2026-04-15T14:00:00.000Z",
+        lastTimestamp: "2026-04-15T16:00:00.000Z",
+        durationMs: 2 * 60 * 60 * 1000,
+        sizeBytes: 1024,
+      },
+    ]);
+    expect(out).toContain("abcd-1234");
+    expect(out).toContain("2.0 hours of context");
+    expect(out).toContain("octopus launch --continue");
+    expect(out).toContain("octopus launch --resume <session-id>");
+  });
+});


### PR DESCRIPTION
## Summary
- Cherry-picked `--resume`/`--continue` + `sessions` subcommand (from PR #2) onto the squashed session work (PR #5 landed on wrong base branch)
- Resolved merge conflicts to integrate both: pod registry + UI improvements + resume support
- Threaded `?instance=` param through all pane links, SSE streams, API calls, and split-pane so pod switching works end-to-end

## Test plan
- [x] 71/71 tests pass (includes both session and UI test suites)
- [x] Typecheck clean
- [ ] Click team-lead on `/?instance=techne` → navigates to `/pane/team-lead?instance=techne`
- [ ] Split-pane streams correct instance's data
- [ ] `parachute-octopus launch --continue` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)