### PR TITLE
docs: make one-tentacle-per-repo the default pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A team layer for [Claude Code](https://docs.claude.com/claude-code) — spawn,
 observe, and coordinate **tentacles** (Claude Code teammates) in any repo.
 
 One central session — the **team-lead** — holds the conversation. From there,
-focused tentacles get spawned into their own tmux panes and pinned to a
-working directory. Each tentacle reads its `CLAUDE.md`, does the focused
-work, self-reviews, and reports back. The team-lead stays at the
-big-picture level; depth happens in parallel.
+long-lasting tentacles get spawned into their own tmux panes, each pinned to
+a repo they steward over time. Each tentacle reads its `CLAUDE.md`,
+accumulates context for the repo it owns, and handles whatever work arises
+there. The team-lead stays at the big-picture level; depth happens in
+parallel.
 
 A small, dark web dashboard shows every live pane at a glance and lets you
 type into any of them from a browser or tablet over Tailscale.
@@ -43,6 +44,23 @@ dashboard.
 > Need just the UI? `octopus ui` runs it standalone (daemonized).
 > Need to stop it? `octopus ui stop`. See *UI lifecycle* below.
 
+## One tentacle per repo
+
+The default pattern: **one long-lasting tentacle per repo**, named after
+the repo (`vault`, `daily`, `octopus`, …). It's pinned to that working
+directory, accumulates context as it handles work there, and sits idle
+between tasks. When new work shows up for that repo, it goes to the same
+tentacle — context is already loaded.
+
+This keeps the roster small and comprehensible: the team-lead sees one arm
+per surface, not one arm per task. Task-scoped tentacles (`vault-polish`,
+`arm-rename`, …) proliferate fast and get hard to track.
+
+Before spawning, check the dashboard — if a tentacle already exists for
+that repo, send it the next task instead of spawning a new one. Spawning
+a task-scoped tentacle is still fine when it's genuinely one-off, but the
+repo-scoped pattern should be the default.
+
 ## How it works
 
 ```
@@ -55,9 +73,9 @@ dashboard.
                   │ Agent({ subagent_type: "tentacle", … })
                   ▼
 ┌──────────┐ ┌──────────┐ ┌──────────┐
-│ tentacle │ │ tentacle │ │ tentacle │   each in its own
-│ pane #1  │ │ pane #2  │ │ pane #N  │   tmux pane, pinned
-└──────────┘ └──────────┘ └──────────┘   to a working dir
+│  vault   │ │  daily   │ │  octopus │   one tentacle per repo,
+│ tentacle │ │ tentacle │ │ tentacle │   each in its own tmux pane,
+└──────────┘ └──────────┘ └──────────┘   pinned to its working dir
 
 ┌─────────────────────────────────────────────────────────┐
 │  octopus ui  →  http://127.0.0.1:6061                   │

--- a/templates/octopus.md
+++ b/templates/octopus.md
@@ -6,4 +6,6 @@ This project uses [parachute-octopus](https://github.com/ParachuteComputer/parac
 - `/report <headline>` — tentacles report back to the team-lead
 - The web dashboard shows all active tentacles and their status
 
+Default pattern: **one long-lasting tentacle per repo**, named after the repo (`vault`, `daily`, `octopus`, …). Before spawning a new one, check whether a tentacle for the target repo already exists — if so, send the task there instead.
+
 Tentacles read their working directory's `CLAUDE.md` on spawn — it is not auto-loaded.

--- a/templates/spawn.md
+++ b/templates/spawn.md
@@ -1,10 +1,26 @@
 ---
-description: Spawn a new tentacle in the octopus team
+description: Spawn a new tentacle in the current team
 ---
 
 # Spawn tentacle
 
 Arguments: `$ARGUMENTS` — expected format `<name> <cwd> <prompt...>`.
+
+## Preferred pattern: one tentacle per repo
+
+Before spawning, check whether a tentacle for this repo already exists
+in the team config. The default convention is **one long-lasting tentacle
+per repo, named after the repo** (`vault`, `daily`, `octopus`, …). If one
+exists, send the task to that tentacle instead of spawning a new one —
+its context for the repo is already loaded.
+
+Spawn a fresh tentacle when:
+
+- No tentacle exists for this repo yet
+- The task is genuinely one-off and scoped outside any single repo
+
+Name the new tentacle after its repo (directory basename of `<cwd>`) unless
+the caller has explicitly chosen a different name.
 
 Parse `$ARGUMENTS`:
 - **First whitespace-delimited token**: tentacle name (must match `^[a-z][a-z0-9-]{1,30}$`)
@@ -14,10 +30,10 @@ Parse `$ARGUMENTS`:
 Validate:
 1. Name matches the regex above
 2. `cwd` is an absolute path that exists and is a directory (quick Bash to confirm)
-3. Name is not already present in the team config. Check
-   `<repo>/.claude/teams/<team>/config.json` first (project-local), falling back
-   to `~/.claude/teams/<team>/config.json` (home-dir). Default `<team>` is
-   `octopus`; use whatever team name this session was launched with.
+3. Name is not already present in the team config. The team name is the value
+   of `$OCTOPUS_TEAM` for this session (check with `echo $OCTOPUS_TEAM`). Look
+   at `<repo>/.claude/teams/<team>/config.json` first (project-local), falling
+   back to `~/.claude/teams/<team>/config.json` (home-dir).
 
 If any check fails, explain what's wrong briefly and stop.
 
@@ -27,7 +43,8 @@ If all checks pass:
 Agent({
   subagent_type: "tentacle",
   name: <name>,
-  team_name: <team>,           // usually "octopus"
+  // Omit team_name — the Agent tool uses the current session's team context
+  // (from $OCTOPUS_TEAM). Only pass team_name to spawn into a different team.
   prompt: "Working directory: <cwd>\n\n<the spawn prompt>"
 })
 ```

--- a/templates/tentacle.md
+++ b/templates/tentacle.md
@@ -4,7 +4,9 @@ description: A focused teammate pinned to a single working directory. Reads the 
 permissionMode: acceptEdits
 ---
 
-You are a **tentacle** — a focused teammate spawned by the team-lead, assigned a specific working directory and task. You handle depth in one place so the team-lead can stay at the big picture.
+You are a **tentacle** — a focused teammate spawned by the team-lead, assigned a specific working directory. You handle depth in one place so the team-lead can stay at the big picture.
+
+By default you are the **long-lasting steward of this repo**: work that arises in this working directory comes to you over time, and you accumulate context as you go. Between tasks you sit idle; when a new task arrives, the team-lead sends it to you because your context is already loaded. (A tentacle can also be spawned for a genuinely one-off task outside any repo — if so, the spawn brief will say so.)
 
 ## First thing you do
 
@@ -23,6 +25,7 @@ Don't start work before doing this. Skipping it is the most common cause of wast
 - **Surface ambiguity.** If the brief is unclear, SendMessage team-lead with the question rather than guessing.
 - **Test between edits.** Run static analysis and tests after every meaningful change if the project has them.
 - **Never auto-merge PRs.** Open the PR, report back, the user decides.
+- **Accumulate context between tasks.** You're long-lasting — idle time is a chance to deepen your map of the repo (read unfamiliar modules, skim recent PRs) so the next task starts warm.
 
 ## How you report back
 


### PR DESCRIPTION
## Summary

Launch-relevant (T-6) polish to the docs & templates that other users inherit via `octopus init`. Encodes the **one long-lasting tentacle per repo** pattern as the default across every surface where the library teaches itself — so what ships at launch reflects the pattern we actually use day-to-day.

- **README.md** — reframe intro + "How it works" diagram; add a short "One tentacle per repo" section that positively teaches the convention (name after the repo, check the dashboard before spawning, task-scoped tentacles still fine when genuinely needed).
- **templates/spawn.md** — prepend a "Preferred pattern" section so the team-lead checks for an existing repo-scoped tentacle first and names new ones after the repo basename.
- **templates/tentacle.md** — frame the tentacle as "long-lasting steward of this repo"; add a bullet about using idle time to deepen repo context so the next task starts warm.
- **templates/octopus.md** — one-liner surfaced in every `octopus init`'d repo's CLAUDE.md pointing to the per-repo default.

No schema or code changes — this is a norm, not a constraint. Non-repo tentacles remain possible when genuinely needed (the docs explicitly carve that out).

## Scope note

templates/spawn.md also absorbs a pre-existing local in-flight edit that refactors team-name resolution to `$OCTOPUS_TEAM` (dropping the stale `team_name` arg and "always octopus" default). That edit was already in the working tree when I started and is consistent with the overall polish; bundled here to keep spawn.md's two slices of polish together, but calling it out so it isn't missed on review.

## Test plan

- [x] `bun test` — 71 pass, 0 fail (init.test.ts still happy — the fenced-section markers and `# Octopus` heading all preserved)
- [ ] Eyeball `octopus init` against a fresh temp dir to confirm the new octopus.md line lands in CLAUDE.md as expected
- [ ] Read through the rendered README on GitHub once merged to sanity-check the new section placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)