### PR TITLE
fix(report): detect SendMessage availability and fail loudly

### DIFF
--- a/templates/octopus.md
+++ b/templates/octopus.md
@@ -7,3 +7,12 @@ This project uses [parachute-octopus](https://github.com/ParachuteComputer/parac
 - The web dashboard shows all active tentacles and their status
 
 Tentacles read their working directory's `CLAUDE.md` on spawn — it is not auto-loaded.
+
+## Where reports land
+
+Tentacles have two backends with different delivery paths:
+
+- **tmux-backed tentacles** deliver reports via `SendMessage` into the team-lead's inbox. Check the inbox / dashboard as usual.
+- **Agent-backed subagents** (spawned via the `Agent` tool) cannot `SendMessage`. Their report is returned as the subagent's **final assistant message** — you'll see it inline in the `Agent` tool's completion result, not in the inbox. Read the completion payload to get the report.
+
+If you spawn an Agent-backed tentacle and nothing shows up in the inbox, that's expected — look at the `Agent` call's return value for the report.

--- a/templates/report.md
+++ b/templates/report.md
@@ -6,16 +6,43 @@ description: Report back to the team-lead with a structured summary
 
 Arguments: `$ARGUMENTS` — a one-line headline for what you're reporting. Write the full body of the report as your next Claude Code reply after invocation.
 
-When this runs:
+## Why this has two paths
 
-1. **SendMessage to `team-lead`** with a structured summary containing:
+Tentacles run in one of two backends, and the report path differs between them:
+
+- **tmux-backed tentacles** (full Claude Code session in a tmux pane) have `SendMessage` available and can deliver reports into the team-lead's inbox.
+- **Agent-backed subagents** (spawned via the `Agent` tool, e.g. the `tentacle` subagent type) do **not** have `SendMessage`. Their only channel back to the parent session is their final assistant message, which the `Agent` tool surfaces verbatim.
+
+If `/report` blindly calls `SendMessage` without checking, an Agent-backed subagent silently drops the report. If it prints "Reported: ..." locally without having actually sent anything, the acknowledgement is a lie. Both are bugs. Follow the steps below.
+
+## Steps
+
+1. **Assemble the structured summary** (you'll need it either way):
    - What you did (1-3 bullets)
    - PR link (if any) — inline, not as a separate bullet
    - What's unresolved or blocked
    - Decision points that need the user's call
    - Anything you cut vs. what was briefed, and why
 
-2. Acknowledge briefly to the local pane: `Reported: <headline>.`
+2. **Check whether `SendMessage` is available.** The cheapest way is to attempt the call and catch failure. You can also use `ToolSearch` with `select:SendMessage` to confirm the schema is loaded before calling. Treat "tool not found" / "unknown tool" / `InputValidationError` on an unloaded schema as "not available."
+
+3. **Route based on availability:**
+
+   - **If `SendMessage` is available (tmux-backed):**
+     - Call `SendMessage` to recipient `team-lead` with the structured summary from step 1.
+     - Only after the send succeeds, acknowledge locally with exactly: `Reported to team-lead: <headline>.`
+     - If the send fails, do **not** print the "Reported" acknowledgement. Fall through to the Agent-backed path below and say the send failed.
+
+   - **If `SendMessage` is not available (Agent-backed subagent):**
+     - Emit the full structured summary from step 1 as your **final assistant message** for this turn. The `Agent` tool surfaces this message verbatim to the parent session — that *is* the report delivery.
+     - In the same final message, include a short tail line: `No inbox available (Agent-backed subagent); full report returned above.`
+     - Do **not** print `Reported to team-lead: ...` — nothing was sent to an inbox.
+
+## Invariants
+
+- Never print `Reported to team-lead: ...` unless a `SendMessage` call actually succeeded.
+- Never silently drop a report. If you can't send, surface the report in your final assistant message so the parent session can see it.
+- Failure is loud. Prefer an explicit "send failed, here is the report inline" over a misleading success acknowledgement.
 
 ## Report contract
 
@@ -23,4 +50,4 @@ Each tentacle's spawn brief can include a **Report contract** section that speci
 - Expected report shape (fixed bullet list with known fields vs. free-form)
 - Any additional reporting steps (e.g., persisting to an external system)
 
-If the brief doesn't specify, default to: SendMessage-only, structured summary.
+If the brief doesn't specify, default to: structured summary, routed by the rules above.

--- a/templates/tentacle.md
+++ b/templates/tentacle.md
@@ -26,7 +26,7 @@ Don't start work before doing this. Skipping it is the most common cause of wast
 
 ## How you report back
 
-When done (or stuck), SendMessage team-lead:
+When done (or stuck), report to team-lead with this structure:
 
 ```
 ### Status
@@ -40,3 +40,12 @@ Anything the team-lead should know.
 ```
 
 If stuck, say what you tried and what's blocking.
+
+## How your reports reach team-lead
+
+Tentacles run in one of two backends, and the delivery path differs:
+
+- **tmux-backed (full Claude Code session in a tmux pane):** you have `SendMessage` available. Call it with recipient `team-lead` to drop the report in the team-lead's inbox. This is the traditional path — the team-lead pane sees it asynchronously.
+- **Agent-backed (spawned via the `Agent` tool as a `tentacle` subagent):** you do **not** have `SendMessage`. The `Agent` tool surfaces your **final assistant message** verbatim to the parent session when your turn completes. That final message *is* the report delivery — write the structured report there directly.
+
+The `/report` skill handles both cases: it detects which backend you're running in and routes correctly. Use it rather than hand-rolling a report. If you're Agent-backed and try to `SendMessage` directly, the call fails and the report is silently dropped — always go through `/report`.


### PR DESCRIPTION
## Summary

- `/report` previously assumed `SendMessage` was always available. Agent-backed subagents (spawned via the `Agent` tool as a `tentacle` subagent) do not have `SendMessage`, so their reports were silently dropped while the local pane still printed a confident "Reported: ..." acknowledgement.
- This PR rewrites `templates/report.md` so the skill first checks whether `SendMessage` is available. tmux-backed tentacles continue to deliver via the inbox; Agent-backed subagents emit the structured report as their final assistant message (which the `Agent` tool surfaces verbatim to the parent session). The "Reported to team-lead" acknowledgement is only printed when a send actually succeeded.
- Also documents the two-backend reality in `templates/tentacle.md` (tentacle-side, "How your reports reach team-lead") and `templates/octopus.md` (parent-side, "Where reports land") so both sides know what to expect.

This is a docs-only change to the templates that `octopus init` writes into target repos. The broader "should `/spawn` default to tmux-backed or Agent-backed?" question is tracked in a follow-up GitHub issue.

## Test plan

- [x] `bun test` — 71 pass, 0 fail (unchanged)
- [ ] After merge, re-run an Agent-backed tentacle and confirm the report comes back as the final assistant message instead of being silently dropped.
- [ ] Confirm tmux-backed tentacles still deliver via the team-lead inbox as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)