### PR TITLE
fix(spawn): restore team_name in Agent call, source from $OCTOPUS_TEAM

### DIFF
--- a/templates/report.md
+++ b/templates/report.md
@@ -17,6 +17,22 @@ When this runs:
 
 2. Acknowledge briefly to the local pane: `Reported: <headline>.`
 
+## If `SendMessage` isn't available
+
+You should have `SendMessage` in your tool surface — tentacles spawned via
+the `/spawn` skill join their parent session's team (`team_name` from
+`$OCTOPUS_TEAM`) and inherit the full team-messaging tools.
+
+If the send fails or `SendMessage` is absent, you were spawned without a
+proper `team_name` (upstream bug in the `/spawn` skill). In that case:
+
+- Emit the structured summary as your **final assistant message** so the
+  parent `Agent` call surfaces it verbatim.
+- Add a tail line: `No SendMessage available — spawn context missing team_name. See parachute-octopus templates/spawn.md.`
+- Do **not** print `Reported: ...` — nothing reached an inbox.
+
+Failure is loud. Never silently drop a report.
+
 ## Report contract
 
 Each tentacle's spawn brief can include a **Report contract** section that specifies:

--- a/templates/spawn.md
+++ b/templates/spawn.md
@@ -1,5 +1,5 @@
 ---
-description: Spawn a new tentacle in the octopus team
+description: Spawn a new tentacle in the current team
 ---
 
 # Spawn tentacle
@@ -11,25 +11,68 @@ Parse `$ARGUMENTS`:
 - **Second whitespace-delimited token**: working directory — an absolute path
 - **Everything after the second token**: the spawn prompt, preserved as-is (newlines in the prompt arrive as literal characters — keep them)
 
-Validate:
+## Team resolution
+
+The team name comes from the session env (`$OCTOPUS_TEAM`, set by
+`parachute-octopus launch`). Resolve it with a quick Bash:
+
+```
+echo $OCTOPUS_TEAM
+```
+
+Use whatever comes back as `<team>`. If it's empty, fall back to `octopus`
+(the legacy default) and mention the miss in your acknowledgement so Aaron
+can re-launch with the right team next time.
+
+**Do not omit `team_name` from the Agent call.** Without it, the Agent tool
+falls back to an auto-generated UUID-keyed team per parent session — the
+tentacle joins that ghost team instead of `<team>`, and becomes invisible
+to the dashboard and the team-lead's inbox. This is the bug that used to
+silently swallow reports.
+
+## Validate
+
 1. Name matches the regex above
 2. `cwd` is an absolute path that exists and is a directory (quick Bash to confirm)
-3. Name is not already present in the team config. Check
-   `<repo>/.claude/teams/<team>/config.json` first (project-local), falling back
-   to `~/.claude/teams/<team>/config.json` (home-dir). Default `<team>` is
-   `octopus`; use whatever team name this session was launched with.
+3. The team config exists at `~/.claude/teams/<team>/config.json` (project-local
+   `<repo>/.claude/teams/<team>/config.json` also fine). If missing, ask Aaron
+   to create it with `TeamCreate({team_name: "<team>", ...})` first — don't
+   try to spawn into a non-existent team.
+4. Name is not already present in that team's `config.json`
 
 If any check fails, explain what's wrong briefly and stop.
 
-If all checks pass:
+## Spawn
+
+If all checks pass, invoke:
 
 ```
 Agent({
   subagent_type: "tentacle",
   name: <name>,
-  team_name: <team>,           // usually "octopus"
+  team_name: "<team>",        // REQUIRED — from $OCTOPUS_TEAM
   prompt: "Working directory: <cwd>\n\n<the spawn prompt>"
 })
 ```
 
-Then acknowledge: `Spawned \`<name>\` in \`<cwd>\`.` — one short line, nothing more.
+The Agent runtime creates the tmux pane, registers the tentacle in
+`~/.claude/teams/<team>/config.json` with a `tmuxPaneId`, and gives the new
+session the full team-messaging tool surface (`SendMessage`, inbox, etc.).
+The dashboard picks it up on its next 2s poll.
+
+## Acknowledge
+
+Then acknowledge with one short line:
+
+```
+Spawned `<name>` in `<cwd>` (team: <team>).
+```
+
+Nothing more.
+
+## Optional: explicit team override
+
+If Aaron wants to spawn into a *different* team than `$OCTOPUS_TEAM` (rare —
+cross-team dispatch), accept that as an out-of-band instruction and pass
+that team name as `team_name` instead. Announce the override in the
+acknowledgement.

--- a/templates/tentacle.md
+++ b/templates/tentacle.md
@@ -26,7 +26,8 @@ Don't start work before doing this. Skipping it is the most common cause of wast
 
 ## How you report back
 
-When done (or stuck), SendMessage team-lead:
+Use the `/report` skill — it handles the team-lead delivery and the
+fallback path if your team context is missing. The default report shape:
 
 ```
 ### Status
@@ -40,3 +41,11 @@ Anything the team-lead should know.
 ```
 
 If stuck, say what you tried and what's blocking.
+
+## Your team context
+
+You were spawned by the team-lead via `/spawn`, which called
+`Agent(team_name: "<team>", ...)` — so you share the parent's team. That
+means `SendMessage`, the team-lead's inbox, and the dashboard all work out
+of the box. If any of those tools are missing from your surface, say so
+in your report so Aaron can fix the spawn path upstream.


### PR DESCRIPTION
## Summary

- Recent edit to `templates/spawn.md` dropped `team_name` from the Agent call on the theory the Agent tool would infer team context from `$OCTOPUS_TEAM`. It doesn't — it falls back to an auto-generated UUID-keyed team (`d42786c1-...`) per parent session. Tentacles landed in that ghost team: invisible to the dashboard, unreachable from the team-lead's inbox, silent report drops.
- Fix: reinstate `team_name` in the Agent call, explicitly sourced from `$OCTOPUS_TEAM`. Add validation that the target team config exists before spawning (if missing, ask Aaron to `TeamCreate` first — don't silently ghost-team).
- Document the failure mode so a future regression is loud rather than silent.

## What changed

- **`templates/spawn.md`** — "Team resolution" section documents sourcing `<team>` from `echo $OCTOPUS_TEAM`, why `team_name` is required, and what happens if it's omitted. Validation adds a team-config-exists check. The Agent call sets `team_name: "<team>"` with a REQUIRED comment. Acknowledgement now includes the team name. Optional "explicit team override" subsection for cross-team dispatch.
- **`templates/report.md`** — Adds a "If `SendMessage` isn't available" path that surfaces the report as the final assistant message AND names the upstream bug (missing `team_name`), so any future spawn-path regression doesn't silently drop reports.
- **`templates/tentacle.md`** — Points tentacles at `/report` (instead of hand-rolling SendMessage). Adds "Your team context" so tentacles know their team wiring and flag breakage upstream.

## What I dropped (per revised scope)

The first revision of this change went down a rabbit hole of "tmux-backed vs Agent-backed" and raw `tmux new-window` shelling from the skill. Aaron corrected that framing mid-task: the Claude Code `Agent(team_name: ...)` primitive handles tmux pane creation internally — there's only one backing, not two. This PR reflects the corrected framing. `src/cli/spawn.ts` and all tmux command wiring are untouched.

## Not code

No `src/` changes. Templates only.

## Test plan

- [x] `bun test` — 71 pass, 0 fail (unchanged)
- [ ] After merge, re-run `octopus init` in an active pod (or copy `templates/spawn.md` into the target repo's `.claude/commands/spawn.md`) so the team-lead picks up the new skill text. Current sessions cache skills on launch — may need a `/compact` or re-launch to reload.
- [ ] Spawn a tentacle via `/spawn`, confirm it appears in `~/.claude/teams/$OCTOPUS_TEAM/config.json` members with a `tmuxPaneId` set, and that the dashboard's live grid shows it (was the whole point of the fix).
- [ ] Confirm the spawned tentacle can `SendMessage` back to the team-lead and the report lands in the inbox (not in the UUID ghost team).

## Related

Addresses the root cause of the symptoms that motivated #10 (report routing fallback) — the real bug was spawn-path, not report-path. With `team_name` set correctly, `SendMessage` is always available to tentacles and the two-backend dichotomy in #10 dissolves. #10 and this PR can both land (defense in depth), or #10 can be superseded.

Partially addresses #11's design question: "tmux-backed vs Agent-backed" was a false dichotomy — with the primitives used correctly, they're the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)