### PR TITLE
fix(ui): default to our tmux session, reject cross-team primary panes

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -80,6 +80,8 @@ function helpEnv(): void {
 
   OCTOPUS_TEAM            default team name (default: octopus)
   OCTOPUS_TEAM_CONFIG     absolute path to config.json (skips lookup)
+  OCTOPUS_TMUX_SESSION    tmux session to filter pane scans to (set by
+                          \`octopus launch\`/\`octopus ui --tmux-session\`)
   OCTOPUS_UI_PORT         dashboard port (default: 6061)
   OCTOPUS_UI_HOST         dashboard bind address (default: 0.0.0.0)
   OCTOPUS_UI_POLL_MS      snapshot interval in ms (default: 2000)

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -72,6 +72,11 @@ function applyEnv(opts: UiOptions): void {
   process.env.OCTOPUS_UI_PORT = String(opts.port);
   process.env.OCTOPUS_UI_HOST = opts.host;
   if (opts.pollMs) process.env.OCTOPUS_UI_POLL_MS = opts.pollMs;
+  // Thread the tmux session name through to the server so it can filter
+  // pane listings to our team's session by default (no ?instance= required).
+  // Without this, the dashboard scans every tmux pane on the box and can
+  // match a primary-session-looking pane from a different team.
+  if (opts.tmuxSession) process.env.OCTOPUS_TMUX_SESSION = opts.tmuxSession;
 }
 
 function displayUrl(host: string, port: number): string {

--- a/src/ui/server.tsx
+++ b/src/ui/server.tsx
@@ -25,18 +25,35 @@ const TEAM_NAME = process.env.OCTOPUS_TEAM ?? "octopus";
 const TEAM_CONFIG_PATH = resolveTeamConfigPath(TEAM_NAME, process.env.OCTOPUS_TEAM_CONFIG);
 setConfigPath(TEAM_CONFIG_PATH);
 
+// When the UI is launched by `octopus launch`/`octopus ui`, the CLI exports
+// OCTOPUS_TMUX_SESSION so we can filter `tmux list-panes` to our team's
+// session. Without this filter, a primary-session-looking pane from another
+// team on the same host can be picked up as "our" team-lead — the dashboard
+// then shows orphans for the real team's tentacles and reports route to the
+// wrong inbox. The ?instance= query param overrides this per-request.
+const DEFAULT_TMUX_SESSION = process.env.OCTOPUS_TMUX_SESSION?.trim() || undefined;
+
 const PUBLIC_DIR = resolvePublicDir();
 
 const app = new Hono();
 
 function resolveInstanceCtx(c: { req: { query: (k: string) => string | undefined } }): InstanceContext | undefined {
   const instance = c.req.query("instance");
-  if (!instance) return undefined;
-  const pod = loadPod();
-  const entry = pod.octopi.find((o) => o.name === instance);
-  if (!entry) return undefined;
-  const configPath = resolveTeamConfigPath(entry.name, undefined, entry.scope);
-  return { configPath, session: entry.name };
+  if (instance) {
+    const pod = loadPod();
+    const entry = pod.octopi.find((o) => o.name === instance);
+    if (entry) {
+      const configPath = resolveTeamConfigPath(entry.name, undefined, entry.scope);
+      return { configPath, session: entry.name };
+    }
+    // Unknown instance — fall through to the default context rather than
+    // returning undefined, so we still filter to our own tmux session.
+  }
+  // Default context: filter to the session the UI was launched with, if any.
+  // buildSnapshot treats an undefined session as "scan every pane on the box",
+  // which is what causes the cross-team bleed-through this env var fixes.
+  if (DEFAULT_TMUX_SESSION) return { session: DEFAULT_TMUX_SESSION };
+  return undefined;
 }
 
 app.get("/health", (c) => c.json({ ok: true, at: Date.now() }));

--- a/src/ui/state.ts
+++ b/src/ui/state.ts
@@ -172,6 +172,7 @@ export async function buildSnapshot(ctx?: InstanceContext): Promise<Snapshot> {
   // look for any untagged Claude Code pane — that's likely the team-lead.
   const now = Date.now();
   const tentacleNames = new Set(captures.filter((c) => c.name).map((c) => c.name));
+  const memberNames = new Set(config.members.map((m) => m.name));
   let primarySessionCapture = captures.find((c) => isPrimarySessionPane(c.content));
   if (!primarySessionCapture) {
     // Fallback: untagged Claude Code pane (not a tentacle)
@@ -179,12 +180,34 @@ export async function buildSnapshot(ctx?: InstanceContext): Promise<Snapshot> {
       (c) => !c.name && isClaudeCodePane(c.content),
     );
   }
+
+  // Hardening: if our config has tentacle members but the primary we just
+  // detected shares its tmux session with zero of them, the primary is most
+  // likely from a different team. This catches the cross-team bleed-through
+  // bug class even when the per-session filter isn't in play (e.g. tests,
+  // or a UI launched without OCTOPUS_TMUX_SESSION). Empty-config teams skip
+  // the check — we have nothing to cross-reference yet.
+  if (primarySessionCapture) {
+    const tentacleMembers = config.members.filter((m) => m.agentType !== "team-lead");
+    if (tentacleMembers.length > 0) {
+      const primarySession = primarySessionCapture.pane.session;
+      const hasConfigMemberInSession = captures.some(
+        (c) =>
+          c.pane.session === primarySession &&
+          c.name !== null &&
+          memberNames.has(c.name),
+      );
+      if (!hasConfigMemberInSession) {
+        primarySessionCapture = undefined;
+      }
+    }
+  }
+
   if (primarySessionCapture) {
     primaryCache = { paneId: primarySessionCapture.pane.paneId, at: now };
   } else if (primaryCache && now - primaryCache.at < PRIMARY_CACHE_TTL_MS) {
     primarySessionCapture = captures.find((c) => c.pane.paneId === primaryCache!.paneId);
   }
-  const memberNames = new Set(config.members.map((m) => m.name));
   const mentioned = primarySessionCapture
     ? extractMentions(primarySessionCapture.content, memberNames)
     : [];


### PR DESCRIPTION
## Summary

- The dashboard was scanning every tmux pane on the box (unfiltered `listPanes`) and could pick up a primary-session-looking pane from a different team as "our" team-lead. Real tentacles were orphaned in the grid and `SendMessage` routed to the wrong inbox.
- **Fix 1 — thread `OCTOPUS_TMUX_SESSION`:** `applyEnv` in `src/cli/ui.ts` exports it from `opts.tmuxSession` (already set by `octopus launch` via `--tmux-session`, manually settable on `octopus ui`). `server.tsx` reads it at startup and uses it as the default `InstanceContext.session` when no `?instance=` is given.
- **Fix 2 — hardening in `state.ts`:** reject a primary detection when config has tentacle members defined but the primary's tmux session shares zero panes with any of them. Catches the same bug class even without the env filter (tests, `bun src/ui/server.tsx` directly, older launch scripts). Empty-config teams skip the check.
- Documents `OCTOPUS_TMUX_SESSION` in `parachute-octopus help env`.

## Files changed

- `src/cli/ui.ts` — `applyEnv` sets `process.env.OCTOPUS_TMUX_SESSION` from `opts.tmuxSession`.
- `src/ui/server.tsx` — reads env at startup as `DEFAULT_TMUX_SESSION`. `resolveInstanceCtx` returns `{ session: DEFAULT_TMUX_SESSION }` when no `?instance=` resolves, so every route gets the filter by default. `?instance=` still wins per-request for pod navigation.
- `src/ui/state.ts` — added the zero-config-member-panes guard between primary detection and cache update. Hoisted `memberNames` above the guard so it's available.
- `src/cli/help.ts` — documents `OCTOPUS_TMUX_SESSION`.

## Scope note

Coordinator said keep scope tight for launch T-6. No additional cleanup or refactor. This is the minimal set of changes that implements the fix + the optional hardening.

Noticed during investigation but **not touched** (follow-ups if wanted): `/api/pane/:name` in `server.tsx` calls `snapshotForTentacle` without `ctx` (line ~97), so it also benefits from the new default context now that `resolveInstanceCtx` returns one — but only transitively via `buildSnapshot`'s hardening check; the route itself still doesn't pass ctx. Worth threading through for consistency in a future PR.

## Test plan

- [x] `bun test` — 71 pass, 0 fail (unchanged)
- [x] `bun build src/cli.ts --target=bun` — clean build, no TS errors
- [ ] After merge, restart an `octopus launch` session and confirm the dashboard only shows panes from that session (not orphaned tentacles from other teams on the same host)
- [ ] Confirm `?instance=<other-pod>` in the URL still switches to the other pod's view

## Note on base branch

Targeting `main`. PR #12 (the `/spawn` team_name fix) merged into `setup/initial-scaffold` rather than `main`, so `main` HEAD is still at 20b4f19. This PR is orthogonal to #12 — different files, different concern — so rebasing is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)