### PR TITLE
docs: launch-prep audit — worktree isolation, idle SendMessage, pane exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,33 @@ app layer. The default bind host is `0.0.0.0`, which assumes you're on a
 Tailscale-only or firewalled interface. If you're not, pass `--host
 127.0.0.1`. Do not expose it on the open internet.
 
+## Known behaviors
+
+A few rough edges worth knowing about when running tentacles in parallel.
+
+### Worktree isolation for parallel tentacles
+
+Tentacles spawned against the same git repo share the team-lead's checkout
+unless `isolation: "worktree"` is passed. Parallel tentacles that edit files
+without it will trample each other's uncommitted changes. The `/spawn`
+template now recommends `isolation: "worktree"` by default; if you see
+tentacles clobbering each other, verify that flag is being passed.
+
+### Idle tentacles and `SendMessage`
+
+A tentacle that has gone idle (prompt returned, awaiting input) may not
+pick up a queued `SendMessage` immediately — its Claude Code CLI isn't
+actively polling. If a message seems stuck, nudge the pane via the
+dashboard (type a newline or send any key) to wake it and drain the inbox.
+
+### Pane exhaustion
+
+tmux can refuse `new-pane` with "no space for new pane" when a window is
+already heavily split. Octopus moves arm panes to background windows every
+2s (see `buildSnapshot`), but a burst of rapid-fire spawns can outrun that
+sweep. Workaround: wait a few seconds between spawns, or `/exit` any dead
+tentacles via the dashboard to reclaim room.
+
 ## Where octopus sits in the Parachute family
 
 Octopus is one piece of [Parachute](https://github.com/ParachuteComputer):

--- a/bun.lock
+++ b/bun.lock
@@ -8,17 +8,17 @@
         "hono": "^4.6.0",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.13",
         "typescript": "^5.5.0",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hono": "^4.6.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "^1.3.13",
     "typescript": "^5.5.0"
   }
 }

--- a/templates/spawn.md
+++ b/templates/spawn.md
@@ -51,6 +51,7 @@ Agent({
   subagent_type: "tentacle",
   name: <name>,
   team_name: "<team>",        // REQUIRED — from $OCTOPUS_TEAM
+  isolation: "worktree",      // recommended — see below
   prompt: "Working directory: <cwd>\n\n<the spawn prompt>"
 })
 ```
@@ -59,6 +60,21 @@ The Agent runtime creates the tmux pane, registers the tentacle in
 `~/.claude/teams/<team>/config.json` with a `tmuxPaneId`, and gives the new
 session the full team-messaging tool surface (`SendMessage`, inbox, etc.).
 The dashboard picks it up on its next 2s poll.
+
+### Why `isolation: "worktree"`
+
+Without worktree isolation, parallel tentacles spawned against the same repo
+share the team-lead's checkout — uncommitted edits from one tentacle collide
+with another's in the same working tree. The `worktree` isolation mode
+creates a temporary git worktree per tentacle so each gets an isolated copy.
+
+Pass `isolation: "worktree"` by default when:
+
+- The `<cwd>` is (or lives inside) a git repo.
+- The tentacle will edit files, not just read them.
+
+Skip it only for read-only audits, or when the tentacle's `<cwd>` is
+explicitly a pre-made worktree path that the team-lead has prepared.
 
 ## Acknowledge
 


### PR DESCRIPTION
## Summary

Pre-launch audit (Parachute launches tomorrow) surfaced three behaviors worth documenting, plus one trivial dep hygiene fix. No src/ behavior changes — all documentation + templates.

- **`templates/spawn.md`**: recommend `isolation: "worktree"` by default in the `Agent(...)` call. Parallel tentacles against the same repo share the team-lead's checkout and trample each other's uncommitted edits — caught this session when three lens tentacles collided. The worktree flag gives each a temporary git worktree.
- **`README.md`**: new *Known behaviors* section with three entries:
  - Worktree isolation note (mirrors the spawn-template recommendation).
  - Idle-tentacle SendMessage — messages queue but the pane doesn't auto-wake; nudge via the dashboard to drain the inbox.
  - Pane exhaustion — tmux "no space for new pane" under rapid-fire spawns; the 2s background-window sweep can be outrun.
- **`package.json`**: `@types/bun` "latest" → `^1.3.13` so installs are deterministic. Matches the caret style already used for `hono` and `typescript`.

Follow-up issues filed separately for the underlying improvements (auto-cleanup of dead tentacles for pane reclamation; tentacle cwd-verification guard; factor the move-to-background side-effect out of `buildSnapshot`).

## Test plan

- [x] `bun test` — 71 pass
- [x] `bun run typecheck` — clean
- [ ] Human read-through of the README section for accuracy before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)